### PR TITLE
Fix leakage in Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10", "3.11"]
 
   test-array-libs:
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.12"]
 
   upload_coverage:

--- a/src/ndv/viewer/_backends/_vispy.py
+++ b/src/ndv/viewer/_backends/_vispy.py
@@ -92,7 +92,8 @@ class VispyViewerCanvas:
     def __init__(self, set_info: Callable[[str], None]) -> None:
         self._set_info = set_info
         self._canvas = scene.SceneCanvas()
-        self._canvas.events.mouse_move.connect(qthrottled(self._on_mouse_move, 60))
+        self._on_mouse_move_throttled = qthrottled(self._on_mouse_move, 60)
+        self._canvas.events.mouse_move.connect(self._on_mouse_move_throttled)
         self._current_shape: tuple[int, ...] = ()
         self._last_state: dict[Literal[2, 3], Any] = {}
 

--- a/src/ndv/viewer/_viewer.py
+++ b/src/ndv/viewer/_viewer.py
@@ -552,8 +552,8 @@ class NDViewer(QWidget):
 
         def _throttled_func(index: Indices) -> None:
             _self = self_ref()
-            if _self is None:
-                return None
-            return _self._update_data_for_index(index)
+            if _self is not None:
+                _self._update_data_for_index(index)
+            return None
 
         return qthrottled(_throttled_func, 20, leading=True)


### PR DESCRIPTION
Maybe related to #8.
I found that `qthrottled` holds the reference to the widget instance (via `method.__self__`?) and this prevented proper cleanups in Windows. This problem can be solved by using an weak reference inside a local function as is done in this PR, but probably should be somehow handled on `superqt` side (although I'm not sure if it's possible).