### PR TITLE
fix: fix slider signals for pyside6

### DIFF
--- a/src/ndv/viewer/_dims_slider.py
+++ b/src/ndv/viewer/_dims_slider.py
@@ -361,7 +361,9 @@ class DimsSliders(QWidget):
     Maintains the global current index and emits a signal when it changes.
     """
 
-    valueChanged = Signal(dict)  # dict is of type Indices
+    # valueChanged is actually a signal that emits a dict of {dim_key -> index}
+    # but pyside removes the contents of the dict! so we use object instead
+    valueChanged = Signal(object)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)


### PR DESCRIPTION
small fix to allow sliders to work on PySide6.  This is related to #30  ... but doesn't fully enable support yet.  Tests will still fail with either a segfault or a bus error, due to something going on with `ensure_main_thread`.  But this fix at least lets it be "usable" in pyside.  User will likely see a bus error on quit, or something like that.