### PR TITLE
Clean up PyGFX events

### DIFF
--- a/src/ndv/viewer/_backends/_pygfx.py
+++ b/src/ndv/viewer/_backends/_pygfx.py
@@ -69,29 +69,17 @@ class PyGFXImageHandle:
 class _QWgpuCanvas(QWgpuCanvas):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # Every event we want to intercept in the viewer
-        # Must be "ignored" here
-        self._subwidget.mousePressEvent = self._run_and_ignore(
-            self._subwidget.mousePressEvent
-        )
-        self._subwidget.mouseMoveEvent = self._run_and_ignore(
-            self._subwidget.mouseMoveEvent
-        )
-        self._subwidget.mouseReleaseEvent = self._run_and_ignore(
-            self._subwidget.mouseReleaseEvent
-        )
+        self._sup_mouse_event = self._subwidget._mouse_event
+        self._subwidget._mouse_event = self._mouse_event
 
     def sizeHint(self) -> QSize:
         return QSize(512, 512)
 
-    def _run_and_ignore(self, old: Callable) -> Callable:
-        def new(event: QEvent) -> None:
-            # Process the event like normal
-            old(event)
-            # Then
-            event.ignore()
-
-        return new
+    def _mouse_event(
+        self, event_type: str, event: QEvent, *args: Any, **kwargs: Any
+    ) -> None:
+        self._sup_mouse_event(event_type, event, *args, **kwargs)
+        event.ignore()
 
 
 class PyGFXViewerCanvas:

--- a/src/ndv/viewer/_backends/_pygfx.py
+++ b/src/ndv/viewer/_backends/_pygfx.py
@@ -227,6 +227,8 @@ class PyGFXViewerCanvas:
         self, pos_xy: tuple[float, float]
     ) -> tuple[float, float, float]:
         """Map XY canvas position (pixels) to XYZ coordinate in world space."""
+        # Code adapted from:
+        # https://github.com/pygfx/pygfx/pull/753/files#diff-173d643434d575e67f8c0a5bf2d7ea9791e6e03a4e7a64aa5fa2cf4172af05cdR395
         viewport = pygfx.Viewport.from_viewport_or_renderer(self._renderer)
         if not viewport.is_inside(*pos_xy):
             return (-1, -1, -1)

--- a/src/ndv/viewer/_viewer.py
+++ b/src/ndv/viewer/_viewer.py
@@ -170,15 +170,7 @@ class NDViewer(QWidget):
         self._qcanvas = self._canvas.qwidget()
 
         # Install an event filter so we can intercept mouse/key events
-        if hasattr(self._qcanvas, "_subwidget"):
-            # HACK:
-            # this is a hack for the pygfx backend, which wraps the canvas in another
-            # widget that controls all events.
-            # We could technically add another method to PCanvas to get the "filterable"
-            # widget... but we'll just do this for now.
-            self._qcanvas._subwidget.installEventFilter(self)
-        else:
-            self._qcanvas.installEventFilter(self)
+        self._qcanvas.installEventFilter(self)
 
         # the sliders that control the index of the displayed image
         self._dims_sliders = DimsSliders(self)


### PR DESCRIPTION
This PR adds minor improvements to the PyGFX backend:
* Fixes the event filter, as previously events were not being captured, leading to the hover text not being updated.
* Implements `PyGFXViewerCanvas.canvas_to_world` (inspiration taken from pygfx/pygfx#745). Notably, there *seemed* to be a difference in assumptions between pixel centers between vispy and pygfx - we should decide whether we like the decision I made there.