### PR TITLE
feat: RGB support

### DIFF
--- a/examples/rgb.py
+++ b/examples/rgb.py
@@ -1,0 +1,16 @@
+import math
+
+import numpy
+
+import ndv
+
+img = numpy.zeros((256, 256, 4), dtype=numpy.uint8)
+
+for x in range(256):
+    for y in range(256):
+        img[x, y, 0] = x
+        img[x, y, 1] = y
+        img[x, y, 2] = 255 - x
+        img[x, y, 3] = int(math.sqrt((x - 128) ** 2 + (y - 128) ** 2))
+
+n = ndv.imshow(img)

--- a/src/ndv/util.py
+++ b/src/ndv/util.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from qtpy.QtWidgets import QApplication
 
@@ -12,14 +12,16 @@ from .viewer._viewer import NDViewer
 if TYPE_CHECKING:
     from qtpy.QtCore import QCoreApplication
 
+    from .viewer._components import ChannelMode
     from .viewer._data_wrapper import DataWrapper
+    from .viewer._viewer import ChannelModeStr
 
 
 def imshow(
     data: Any | DataWrapper,
     cmap: Any | None = None,
     *,
-    channel_mode: Literal["mono", "composite", "auto"] = "auto",
+    channel_mode: ChannelModeStr | ChannelMode = "auto",
 ) -> NDViewer:
     """Display an array or DataWrapper in a new NDViewer window.
 
@@ -29,7 +31,7 @@ def imshow(
         The data to be displayed. If not a DataWrapper, it will be wrapped in one.
     cmap : Any | None, optional
         The colormap(s) to use for displaying the data.
-    channel_mode : Literal['mono', 'composite'], optional
+    channel_mode : Literal['mono', 'composite', 'rgb', 'rgba', 'auto'], optional
         The initial mode for displaying the channels. By default "mono" will be
         used unless a cmap is provided, in which case "composite" will be used.
 
@@ -39,12 +41,8 @@ def imshow(
         The viewer window.
     """
     app, should_exec = _get_app()
-    if cmap is not None:
-        channel_mode = "composite"
-        if not isinstance(cmap, (list, tuple)):
-            cmap = [cmap]
-    elif channel_mode == "auto":
-        channel_mode = "mono"
+    if cmap is not None and not isinstance(cmap, (list, tuple)):
+        cmap = [cmap]
     viewer = NDViewer(data, colormaps=cmap, channel_mode=channel_mode)
     viewer.show()
     viewer.raise_()

--- a/src/ndv/viewer/_data_wrapper.py
+++ b/src/ndv/viewer/_data_wrapper.py
@@ -134,19 +134,15 @@ class DataWrapper(Generic[ArrayT]):
         """Return the (best guess) axis name for the channel dimension."""
         # for arrays with labeled dimensions,
         # see if any of the dimensions are named "channel"
-        for dimkey, val in self.sizes().items():
+        sizes = self.sizes()
+        for dimkey, val in sizes.items():
             if str(dimkey).lower() in self.COMMON_CHANNEL_NAMES:
                 if val <= self.MAX_CHANNELS:
                     return dimkey
 
         # for shaped arrays, use the smallest dimension as the channel axis
-        shape = getattr(self._data, "shape", None)
-        if isinstance(shape, Sequence):
-            with suppress(ValueError):
-                smallest_dim = min(shape)
-                if smallest_dim <= self.MAX_CHANNELS:
-                    return shape.index(smallest_dim)
-        return None
+        min_key = min(sizes, key=sizes.get)  # type: ignore
+        return min_key if sizes[min_key] <= self.MAX_CHANNELS else None
 
     def save_as_zarr(self, save_loc: str | Path) -> None:
         raise NotImplementedError("save_as_zarr not implemented for this data type.")

--- a/src/ndv/viewer/_lut_control.py
+++ b/src/ndv/viewer/_lut_control.py
@@ -135,3 +135,20 @@ class LutControl(QWidget):
             self._clims.setMinimum(min(mi, self._clims.minimum()))
             self._clims.setMaximum(max(ma, self._clims.maximum()))
             self._clims.setValue((mi, ma))
+
+
+class RGBAControl(LutControl):
+    def __init__(
+        self,
+        name: str = "",
+        handles: Iterable[PImageHandle] = (),
+        parent: QWidget | None = None,
+        cmaplist: Iterable[Any] = (),
+        auto_clim: bool = True,
+    ) -> None:
+        super().__init__("RGB", handles, parent, cmaplist, auto_clim)
+        self._cmap.setVisible(False)
+
+    def _on_cmap_changed(self, cmap: cmap.Colormap) -> None:
+        # NB: No-op
+        pass


### PR DESCRIPTION
This PR aims to enable the viewing of RGB datasets. Users specify that their provided data is RGB using the new `ChannelMode` value. The current mechanism enables this mode when the channel axis (specified through existing means) has exactly three indices.

To enable the selection of different modes, the `ChannelModeButton` is refactored into a `ChannelModeComboBox`, which can be altered based on the data to contain the `rgb` mode.

![image](https://github.com/user-attachments/assets/cc656e8f-21ff-4aeb-8977-e41833581187)

This PR requires review, and likely additional minor cleanup.

Closes #20