### PR TITLE
feat: support GPU-calculated luts in vispy

### DIFF
--- a/examples/zarr_arr.py
+++ b/examples/zarr_arr.py
@@ -12,4 +12,4 @@ except ImportError:
 URL = "https://s3.embl.de/i2k-2020/ngff-example-data/v0.4/tczyx.ome.zarr"
 zarr_arr = zarr.open(URL, mode="r")
 
-ndv.imshow(zarr_arr["s0"].astype('uint16'))
+ndv.imshow(zarr_arr["s0"].astype("uint16"))

--- a/examples/zarr_arr.py
+++ b/examples/zarr_arr.py
@@ -12,4 +12,4 @@ except ImportError:
 URL = "https://s3.embl.de/i2k-2020/ngff-example-data/v0.4/tczyx.ome.zarr"
 zarr_arr = zarr.open(URL, mode="r")
 
-ndv.imshow(zarr_arr["s0"])
+ndv.imshow(zarr_arr["s0"].astype('uint16'))

--- a/src/ndv/views/_vispy/_utils.py
+++ b/src/ndv/views/_vispy/_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from functools import cache
+from typing import TYPE_CHECKING
+
+from vispy.app import Canvas
+from vispy.gloo import gl
+from vispy.gloo.context import get_current_canvas
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextmanager
+def _opengl_context() -> Iterator[None]:
+    """Assure we are running with a valid OpenGL context.
+
+    Only create a Canvas is one doesn't exist. Creating and closing a
+    Canvas causes vispy to process Qt events which can cause problems.
+    Ideally call opengl_context() on start after creating your first
+    Canvas. However it will work either way.
+    """
+    canvas = Canvas(show=False) if get_current_canvas() is None else None
+    try:
+        yield
+    finally:
+        if canvas is not None:
+            canvas.close()
+
+
+@cache
+def get_gl_extensions() -> set[str]:
+    """Get basic info about the Gl capabilities of this machine."""
+    with _opengl_context():
+        return set(filter(None, gl.glGetParameter(gl.GL_EXTENSIONS).split()))
+
+
+FLOAT_EXT = {"GL_ARB_texture_float", "GL_ATI_texture_float", "GL_NV_float_buffer"}
+
+
+@cache
+def supports_float_textures() -> bool:
+    """Check if the current OpenGL context supports float textures."""
+    return bool(FLOAT_EXT.intersection(get_gl_extensions()))

--- a/src/ndv/views/_vispy/_utils.py
+++ b/src/ndv/views/_vispy/_utils.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def _opengl_context() -> Iterator[None]:
     """Assure we are running with a valid OpenGL context.
 
-    Only create a Canvas is one doesn't exist. Creating and closing a
+    Only create a Canvas if one doesn't exist. Creating and closing a
     Canvas causes vispy to process Qt events which can cause problems.
     Ideally call opengl_context() on start after creating your first
     Canvas. However it will work either way.

--- a/src/ndv/views/_vispy/_vispy.py
+++ b/src/ndv/views/_vispy/_vispy.py
@@ -16,6 +16,7 @@ from vispy.util.quaternion import Quaternion
 
 from ndv._types import CursorType
 from ndv.views._app import filter_mouse_events
+from ndv.views._vispy._utils import supports_float_textures
 from ndv.views.bases import ArrayCanvas
 from ndv.views.bases.graphics._canvas_elements import (
     CanvasElement,
@@ -440,6 +441,7 @@ class VispyViewerCanvas(ArrayCanvas):
         self._ndim: Literal[2, 3] | None = None
 
         self._elements: WeakKeyDictionary = WeakKeyDictionary()
+        self._txt_fmt = "auto" if supports_float_textures() else None
 
     @property
     def _camera(self) -> vispy.scene.cameras.BaseCamera:
@@ -476,7 +478,9 @@ class VispyViewerCanvas(ArrayCanvas):
 
     def add_image(self, data: np.ndarray | None = None) -> VispyImageHandle:
         """Add a new Image node to the scene."""
-        img = scene.visuals.Image(data, parent=self._view.scene)
+        img = scene.visuals.Image(
+            data, parent=self._view.scene, texture_format=self._txt_fmt
+        )
         img.set_gl_state("additive", depth_test=False)
         img.interactive = True
         handle = VispyImageHandle(img)
@@ -487,7 +491,10 @@ class VispyViewerCanvas(ArrayCanvas):
 
     def add_volume(self, data: np.ndarray | None = None) -> VispyImageHandle:
         vol = scene.visuals.Volume(
-            data, parent=self._view.scene, interpolation="nearest"
+            data,
+            parent=self._view.scene,
+            interpolation="nearest",
+            texture_format=self._txt_fmt,
         )
         vol.set_gl_state("additive", depth_test=False)
         vol.interactive = True

--- a/src/ndv/views/_vispy/_vispy.py
+++ b/src/ndv/views/_vispy/_vispy.py
@@ -478,6 +478,7 @@ class VispyViewerCanvas(ArrayCanvas):
 
     def add_image(self, data: np.ndarray | None = None) -> VispyImageHandle:
         """Add a new Image node to the scene."""
+        data = _downcast(data)
         img = scene.visuals.Image(
             data, parent=self._view.scene, texture_format=self._txt_fmt
         )
@@ -490,6 +491,7 @@ class VispyViewerCanvas(ArrayCanvas):
         return handle
 
     def add_volume(self, data: np.ndarray | None = None) -> VispyImageHandle:
+        data = _downcast(data)
         vol = scene.visuals.Volume(
             data,
             parent=self._view.scene,
@@ -583,3 +585,14 @@ class VispyViewerCanvas(ArrayCanvas):
             if (handle := self._elements.get(vis)) is not None:
                 elements.append(handle)
         return elements
+
+def _downcast(data: np.ndarray | None) -> np.ndarray | None:
+    """Downcast >32bit data to 32bit."""
+    # downcast to 32bit, preserving int/float
+    if data is not None:
+        if np.issubdtype(data.dtype, np.integer) and data.dtype.itemsize > 2:
+            warnings.warn("Downcasting integer data to uint16.")
+            data = data.astype(np.uint16)
+        elif np.issubdtype(data.dtype, np.floating) and data.dtype.itemsize > 4:
+            data = data.astype(np.float32)
+    return data

--- a/src/ndv/views/_vispy/_vispy.py
+++ b/src/ndv/views/_vispy/_vispy.py
@@ -484,7 +484,7 @@ class VispyViewerCanvas(ArrayCanvas):
                 data, parent=self._view.scene, texture_format=self._txt_fmt
             )
         except ValueError as e:
-            warnings.warn(f'{e}. Falling back to CPUScaledTexture', stacklevel=2)
+            warnings.warn(f"{e}. Falling back to CPUScaledTexture", stacklevel=2)
             img = scene.visuals.Image(data, parent=self._view.scene)
 
         img.set_gl_state("additive", depth_test=False)

--- a/src/ndv/views/_vispy/_vispy.py
+++ b/src/ndv/views/_vispy/_vispy.py
@@ -586,6 +586,7 @@ class VispyViewerCanvas(ArrayCanvas):
                 elements.append(handle)
         return elements
 
+
 def _downcast(data: np.ndarray | None) -> np.ndarray | None:
     """Downcast >32bit data to 32bit."""
     # downcast to 32bit, preserving int/float

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,6 +22,7 @@ EXAMPLES_PY = list(EXAMPLES.glob("*.py"))
 @pytest.mark.allow_leaks
 @pytest.mark.usefixtures("any_app")
 @pytest.mark.parametrize("example", EXAMPLES_PY, ids=lambda x: x.name)
+@pytest.mark.filterwarnings("ignore:Downcasting integer data")
 def test_example(example: Path) -> None:
     try:
         runpy.run_path(str(example))


### PR DESCRIPTION
this uses `texture_format='auto'` for gpus that support it. Which enables some of the calculations to be done on the GPU.  might speed up some stuff for @gselzer ?