### PR TITLE
refactor: Better Styles for wx and jupyter widgets

### DIFF
--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2fe7ce4f36847ffaba8c042bf85b76d",
+       "model_id": "8b582aca26e04cc4a59d755ea986c44f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -22,7 +22,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92985e7df82f47cabfe3ab5ce9ab0498",
+       "model_id": "3141028c938243b59325ff7ab52e1b3f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -38,8 +38,8 @@
     "from ndv import data, imshow\n",
     "\n",
     "viewer = imshow(data.cells3d())\n",
-    "viewer.model.channel_mode = \"composite\"\n",
-    "viewer.model.current_index.update({0: 32})"
+    "viewer.display_model.channel_mode = \"composite\"\n",
+    "viewer.display_model.current_index.update({0: 32})"
    ]
   },
   {
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.model.visible_axes = (0, 3)"
+    "viewer.display_model.visible_axes = (0, 3)"
    ]
   },
   {
@@ -57,8 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.model.default_lut.cmap = \"cubehelix\"\n",
-    "viewer.model.channel_mode = \"grayscale\""
+    "viewer.display_model.default_lut.cmap = \"cubehelix\"\n",
+    "viewer.display_model.channel_mode = \"grayscale\""
    ]
   }
  ],

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -91,6 +91,11 @@ class WxLutView(LutView):
 
     def set_clims(self, clims: tuple[float, float]) -> None:
         self._wxwidget.clims.SetValue(*clims)
+        # FIXME: this is a hack.
+        # it's required to make `set_auto_scale_without_signal` work as intended
+        # But it's not a complete solution.  The general pattern of blocking signals
+        # in Wx needs to be re-evaluated.
+        wx.Yield()
 
     def set_channel_visible(self, visible: bool) -> None:
         self._wxwidget.visible.SetValue(visible)
@@ -194,7 +199,9 @@ class _WxArrayViewer(wx.Frame):
 
         # Channel mode combo box
         self.channel_mode_combo = wx.ComboBox(
-            self, choices=[x.value for x in ChannelMode], style=wx.CB_DROPDOWN
+            self,
+            choices=[ChannelMode.GRAYSCALE.value, ChannelMode.COMPOSITE.value],
+            style=wx.CB_DROPDOWN,
         )
 
         # Reset zoom button
@@ -204,19 +211,22 @@ class _WxArrayViewer(wx.Frame):
         self.luts = wx.BoxSizer(wx.VERTICAL)
 
         btns = wx.BoxSizer(wx.HORIZONTAL)
-        btns.Add(self.channel_mode_combo, 0, wx.RIGHT, 5)
-        btns.Add(self.reset_zoom_btn, 0, wx.RIGHT, 5)
+        btns.AddStretchSpacer()
+        btns.Add(self.channel_mode_combo, 0, wx.ALL, 5)
+        btns.Add(self.reset_zoom_btn, 0, wx.ALL, 5)
 
         # Layout for the panel
-        main_sizer = wx.BoxSizer(wx.VERTICAL)
-        main_sizer.Add(self._data_info_label, 0, wx.EXPAND | wx.BOTTOM, 5)
-        main_sizer.Add(self._canvas, 1, wx.EXPAND | wx.ALL, 5)
-        main_sizer.Add(self._hover_info_label, 0, wx.EXPAND | wx.BOTTOM, 5)
-        main_sizer.Add(self.dims_sliders, 0, wx.EXPAND | wx.BOTTOM, 5)
-        main_sizer.Add(self.luts, 0, wx.EXPAND, 5)
-        main_sizer.Add(btns, 0, wx.EXPAND, 5)
+        inner = wx.BoxSizer(wx.VERTICAL)
+        inner.Add(self._data_info_label, 0, wx.EXPAND | wx.BOTTOM, 5)
+        inner.Add(self._canvas, 1, wx.EXPAND | wx.ALL)
+        inner.Add(self._hover_info_label, 0, wx.EXPAND | wx.BOTTOM)
+        inner.Add(self.dims_sliders, 0, wx.EXPAND | wx.BOTTOM)
+        inner.Add(self.luts, 0, wx.EXPAND)
+        inner.Add(btns, 0, wx.EXPAND)
 
-        self.SetSizer(main_sizer)
+        outer = wx.BoxSizer(wx.VERTICAL)
+        outer.Add(inner, 1, wx.ALL, 10)
+        self.SetSizer(outer)
         self.SetInitialSize(wx.Size(600, 800))
         self.Layout()
 


### PR DESCRIPTION
## Jupyter

### before

<img width="1087" alt="Screenshot 2025-01-12 at 6 38 02 PM" src="https://github.com/user-attachments/assets/04632adc-828d-47af-b6ab-f11e3fdbeaf8" />

### after

<img width="610" alt="Screenshot 2025-01-12 at 6 37 37 PM" src="https://github.com/user-attachments/assets/cd1b80d2-94df-40cc-934f-3620568478f6" />

## wx

### before
<img width="712" alt="Screenshot 2025-01-12 at 6 38 59 PM" src="https://github.com/user-attachments/assets/3f94978c-e9cd-4992-8002-47d0f6b3f23b" />

### after
<img width="712" alt="Screenshot 2025-01-12 at 6 39 25 PM" src="https://github.com/user-attachments/assets/4204fc07-eab8-46e9-972f-1229e9f6b454" />


