### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      extras: "test,vispy,third_party_arrays"
+      extras: "test,vispy,third_party_arrays,pyqt"
       coverage-upload: artifact
       pip-post-installs: "pytest-qt"
       qt: pyqt6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "cmap >=0.4",
     "numpy >=1.22",
-    "pydantic >=2.9",
     "psygnal >=0.10",
+    "pydantic >=2.9",
     "typing_extensions",
 ]
 
@@ -46,7 +47,7 @@ dependencies = [
 [project.optional-dependencies]
 # Supported GUI frontends
 jupyter = ["ipywidgets >=8", "jupyter", "jupyter_rfb >=0.3.3", "glfw"]
-qtextras = ["qtpy >=2", "superqt[cmap,iconify]>=0.7.1"]
+qtextras = ["qtpy >=2", "superqt[iconify]>=0.7.1"]
 pyqt = ["pyqt6", "ndv[qtextras]"]
 pyside = ["pyside6<6.8", "ndv[qtextras]"]
 wxpython = ["wxpython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "cmap >=0.4",
+    "cmap >=0.3",
     "numpy >=1.22",
     "psygnal >=0.10",
     "pydantic >=2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 dependencies = [
@@ -170,7 +171,7 @@ filterwarnings = [
     # CI-only error on jupyter, vispy, macos
     "ignore:.*Failed to find a suitable pixel format",
     # unsolved python 3.10 warning on shutdown, either xarray or dask
-    "ignore:unclosed transport:ResourceWarning", 
+    "ignore:unclosed transport:ResourceWarning",
 ]
 markers = ["allow_leaks: mark test to allow widget leaks"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ sources = ["src"]
 [project]
 name = "ndv"
 dynamic = ["version"]
-description = "simple nd image viewer"
+description = "Simple, fast-loading, n-dimensional array viewer, with minimal dependencies."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,20 +36,19 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "qtpy",
-    "numpy",
-    "superqt[cmap,iconify]",
-    "pydantic",
-    "psygnal",
+    "numpy >=1.22",
+    "pydantic >=2.9",
+    "psygnal >=0.10",
     "typing_extensions",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 # Supported GUI frontends
-jupyter = ["ipywidgets", "jupyter", "jupyter_rfb", "glfw"]
-pyqt = ["pyqt6"]
-pyside = ["pyside6<6.8"]
+jupyter = ["ipywidgets >=8", "jupyter", "jupyter_rfb >=0.3.3", "glfw"]
+qtextras = ["qtpy >=2", "superqt[cmap,iconify]>=0.7.1"]
+pyqt = ["pyqt6", "ndv[qtextras]"]
+pyside = ["pyside6<6.8", "ndv[qtextras]"]
 wxpython = ["wxpython"]
 
 # Supported Canavs backends

--- a/src/ndv/views/_app.py
+++ b/src/ndv/views/_app.py
@@ -349,7 +349,11 @@ class JupyterProvider(GuiProvider):
             raise RuntimeError(  # pragma: no cover
                 "Jupyter is not running a notebook shell.  Cannot create app."
             )
-        return None
+        # No app creation needed...
+        # but make sure we can actually import the stuff we need
+        import ipywidgets  # noqa: F401
+        import jupyter  # noqa: F401
+        import jupyter_rfb  # noqa: F401
 
     @staticmethod
     def exec() -> None:


### PR DESCRIPTION
should have done this before the release, but when I was making the conda recipe I noticed that we still depend on qtpy and superqt invariably.   We also don't have lower pins.  

I just tested a bunch of stuff to determine lower pins (can do this on CI later) and moved the qt extras into the qt-specific extras