### PR TITLE
refactor: extract GUI-specific logic to GUI folders

### DIFF
--- a/src/ndv/views/_app.py
+++ b/src/ndv/views/_app.py
@@ -96,8 +96,10 @@ class VispyProvider(CanvasProvider):
             use_app("jupyter_rfb")
         elif _frontend == GuiFrontend.WX:
             use_app("wx")
-        # there is no `use_app('qt')`... it's all specific to pyqt/pyside, etc...
-        # so we just let vispy autodetect it
+        elif _frontend == GuiFrontend.QT:
+            from qtpy import API_NAME
+
+            use_app(API_NAME.lower())
 
         return VispyArrayCanvas
 
@@ -144,7 +146,8 @@ CANVAS_PROVIDERS: dict[CanvasBackend, CanvasProvider] = {
 }
 
 
-def running_apps() -> Iterator[GuiFrontend]:
+def _running_apps() -> Iterator[GuiFrontend]:
+    """Return an iterator of running GUI applications."""
     for mod_name in ("PyQt5", "PySide2", "PySide6", "PyQt6"):
         if mod := sys.modules.get(f"{mod_name}.QtWidgets"):
             if (
@@ -175,7 +178,7 @@ def ndv_app() -> NDVApp:
     known GUI providers are tried in order until one is found that is either already
     running, or available.
     """
-    running = list(running_apps())
+    running = list(_running_apps())
 
     requested = os.getenv(GUI_ENV_VAR, "").lower()
     valid = {x.value for x in GuiFrontend}

--- a/src/ndv/views/_app.py
+++ b/src/ndv/views/_app.py
@@ -3,19 +3,15 @@ from __future__ import annotations
 import importlib.util
 import os
 import sys
-import traceback
-from concurrent.futures import Executor, Future, ThreadPoolExecutor
-from contextlib import suppress
 from enum import Enum
 from functools import cache, wraps
-from types import MethodType
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol, cast
+from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
-from ndv._types import MouseMoveEvent, MousePressEvent, MouseReleaseEvent
+from ndv.views.bases._app import NDVApp
 
 if TYPE_CHECKING:
-    from collections.abc import Container
-    from types import TracebackType
+    from collections.abc import Iterator
+    from concurrent.futures import Future
 
     from IPython.core.interactiveshell import InteractiveShell
     from typing_extensions import ParamSpec, TypeVar
@@ -31,15 +27,6 @@ GUI_ENV_VAR = "NDV_GUI_FRONTEND"
 
 CANVAS_ENV_VAR = "NDV_CANVAS_BACKEND"
 """Preferred canvas backend. If not set, the first available canvas backend is used."""
-
-DEBUG_EXCEPTIONS = "NDV_DEBUG_EXCEPTIONS"
-"""Whether to drop into a debugger when an exception is raised. Default False."""
-
-EXIT_ON_EXCEPTION = "NDV_EXIT_ON_EXCEPTION"
-"""Whether to exit the application when an exception is raised. Default False."""
-
-IPYTHON_GUI_MAGIC = "NDV_IPYTHON_MAGIC"
-"""Whether to use %gui magic when running in IPython. Default True."""
 
 
 class GuiFrontend(str, Enum):
@@ -75,35 +62,6 @@ class CanvasBackend(str, Enum):
     PYGFX = "pygfx"
 
 
-class GuiProvider(Protocol):
-    @staticmethod
-    def is_running() -> bool: ...
-    @staticmethod
-    def create_app() -> bool: ...
-    @staticmethod
-    def array_view_class() -> type[ArrayView]: ...
-    @staticmethod
-    def exec() -> None: ...
-    @staticmethod
-    def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]: ...
-    @staticmethod
-    def call_in_main_thread(
-        func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
-    ) -> Future[T]:
-        future: Future[T] = Future()
-        future.set_result(func(*args, **kwargs))
-        return future
-
-    @staticmethod
-    def get_executor() -> Executor:
-        return _thread_pool_executor()
-
-
-@cache
-def _thread_pool_executor() -> ThreadPoolExecutor:
-    return ThreadPoolExecutor(max_workers=2)
-
-
 class CanvasProvider(Protocol):
     @staticmethod
     def is_imported() -> bool: ...
@@ -113,289 +71,6 @@ class CanvasProvider(Protocol):
     def array_canvas_class() -> type[ArrayCanvas]: ...
     @staticmethod
     def histogram_canvas_class() -> type[HistogramCanvas]: ...
-
-
-# FIXME:
-# the implementation below has a lot of nested imports that will be largely
-# unnecessary after the GUI has been decided.  Consider alternative patterns.
-# primarily, we need to avoid importing any frontends "accidentally".  But beyond
-# that, it can be refactored as needed.
-
-
-class QtProvider(GuiProvider):
-    """Provider for PyQt5/PySide2/PyQt6/PySide6."""
-
-    _APP_INSTANCE: ClassVar[Any] = None
-
-    @staticmethod
-    def is_running() -> bool:
-        for mod_name in ("PyQt5", "PySide2", "PySide6", "PyQt6"):
-            if mod := sys.modules.get(f"{mod_name}.QtWidgets"):
-                if qapp := getattr(mod, "QApplication", None):
-                    return qapp.instance() is not None
-        return False
-
-    @staticmethod
-    def create_app() -> Any:
-        from qtpy.QtWidgets import QApplication
-
-        if (qapp := QApplication.instance()) is None:
-            # if we're running in IPython
-            # start the %gui qt magic if NDV_IPYTHON_MAGIC!=0
-            if (ipy_shell := _ipython_shell()) and (
-                os.getenv(IPYTHON_GUI_MAGIC, "true").lower() not in ("0", "false", "no")
-            ):
-                ipy_shell.enable_gui("qt")  # type: ignore [no-untyped-call]
-            # otherwise create a new QApplication
-            else:
-                # must be stored in a class variable to prevent garbage collection
-                QtProvider._APP_INSTANCE = qapp = QApplication(sys.argv)
-                qapp.setOrganizationName("ndv")
-                qapp.setApplicationName("ndv")
-
-        _install_excepthook()
-        return qapp
-
-    @staticmethod
-    def exec() -> None:
-        from qtpy.QtWidgets import QApplication
-
-        app = QApplication.instance() or QtProvider.create_app()
-
-        for wdg in QApplication.topLevelWidgets():
-            wdg.raise_()
-
-        if ipy_shell := _ipython_shell():
-            # if we're already in an IPython session with %gui qt, don't block
-            if str(ipy_shell.active_eventloop).startswith("qt"):
-                return
-
-        app.exec()
-
-    @staticmethod
-    def call_in_main_thread(
-        func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
-    ) -> Future[T]:
-        from ._qt._main_thread import call_in_main_thread
-
-        return call_in_main_thread(func, *args, **kwargs)
-
-    @staticmethod
-    def array_view_class() -> type[ArrayView]:
-        from ._qt._array_view import QtArrayView
-
-        return QtArrayView
-
-    @staticmethod
-    def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]:
-        from qtpy.QtCore import QEvent, QObject
-        from qtpy.QtGui import QMouseEvent
-
-        if not isinstance(canvas, QObject):
-            raise TypeError(f"Expected canvas to be QObject, got {type(canvas)}")
-
-        class Filter(QObject):
-            def eventFilter(self, obj: QObject | None, qevent: QEvent | None) -> bool:
-                """Event filter installed on the canvas to handle mouse events.
-
-                here is where we get a chance to intercept mouse events before allowing
-                the canvas to respond to them. Return `True` to prevent the event from
-                being passed to the canvas.
-                """
-                if qevent is None:
-                    return False  # pragma: no cover
-
-                try:
-                    # use children in case backend has a subwidget stealing events.
-                    children: Container = canvas.children()
-                except RuntimeError:
-                    # native is likely dead
-                    return False
-
-                intercept = False
-                if obj is canvas or obj in children:
-                    if isinstance(qevent, QMouseEvent):
-                        pos = qevent.pos()
-                        etype = qevent.type()
-                        if etype == QEvent.Type.MouseMove:
-                            mme = MouseMoveEvent(x=pos.x(), y=pos.y())
-                            intercept |= receiver.on_mouse_move(mme)
-                            receiver.mouseMoved.emit(mme)
-                        elif etype == QEvent.Type.MouseButtonPress:
-                            mpe = MousePressEvent(x=pos.x(), y=pos.y())
-                            intercept |= receiver.on_mouse_press(mpe)
-                            receiver.mousePressed.emit(mpe)
-                        elif etype == QEvent.Type.MouseButtonRelease:
-                            mre = MouseReleaseEvent(x=pos.x(), y=pos.y())
-                            intercept |= receiver.on_mouse_release(mre)
-                            receiver.mouseReleased.emit(mre)
-                return intercept
-
-        f = Filter()
-        canvas.installEventFilter(f)
-        return lambda: canvas.removeEventFilter(f)
-
-
-class WxProvider(GuiProvider):
-    """Provider for wxPython."""
-
-    @staticmethod
-    def is_running() -> bool:
-        if wx := sys.modules.get("wx"):
-            return wx.App.Get() is not None
-        return False
-
-    @staticmethod
-    def create_app() -> Any:
-        import wx
-
-        if (wxapp := wx.App.Get()) is None:
-            wxapp = wx.App()
-        # if we're running in IPython
-        # start the %gui qt magic if NDV_IPYTHON_MAGIC!=0
-        if (ipy_shell := _ipython_shell()) and (
-            os.getenv(IPYTHON_GUI_MAGIC, "true").lower() not in ("0", "false", "no")
-        ):
-            ipy_shell.enable_gui("wx")  # type: ignore [no-untyped-call]
-
-        _install_excepthook()
-        from ._wx._main_thread import call_in_main_thread  # noqa: F401
-
-        return wxapp
-
-    @staticmethod
-    def exec() -> None:
-        import wx
-
-        app = cast("wx.App", wx.App.Get() or WxProvider.create_app())
-
-        if ipy_shell := _ipython_shell():
-            # if we're already in an IPython session with %gui qt, don't block
-            if str(ipy_shell.active_eventloop).startswith("wx"):
-                return
-
-        app.MainLoop()
-
-    @staticmethod
-    def call_in_main_thread(
-        func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
-    ) -> Future[T]:
-        from ._wx._main_thread import call_in_main_thread
-
-        return call_in_main_thread(func, *args, **kwargs)
-
-    @staticmethod
-    def array_view_class() -> type[ArrayView]:
-        from ._wx._array_view import WxArrayView
-
-        return WxArrayView
-
-    @staticmethod
-    def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]:
-        from wx import EVT_LEFT_DOWN, EVT_LEFT_UP, EVT_MOTION, EvtHandler, MouseEvent
-
-        if not isinstance(canvas, EvtHandler):
-            raise TypeError(
-                f"Expected vispy canvas to be wx EvtHandler, got {type(canvas)}"
-            )
-
-        # TIP: event.Skip() allows the event to propagate to other handlers.
-
-        def on_mouse_move(event: MouseEvent) -> None:
-            mme = MouseMoveEvent(x=event.GetX(), y=event.GetY())
-            if not receiver.on_mouse_move(mme):
-                receiver.mouseMoved.emit(mme)
-                event.Skip()
-
-        def on_mouse_press(event: MouseEvent) -> None:
-            mpe = MousePressEvent(x=event.GetX(), y=event.GetY())
-            if not receiver.on_mouse_press(mpe):
-                receiver.mousePressed.emit(mpe)
-                event.Skip()
-
-        def on_mouse_release(event: MouseEvent) -> None:
-            mre = MouseReleaseEvent(x=event.GetX(), y=event.GetY())
-            if not receiver.on_mouse_release(mre):
-                receiver.mouseReleased.emit(mre)
-                event.Skip()
-
-        canvas.Bind(EVT_MOTION, on_mouse_move)
-        canvas.Bind(EVT_LEFT_DOWN, on_mouse_press)
-        canvas.Bind(EVT_LEFT_UP, on_mouse_release)
-
-        def _unbind() -> None:
-            canvas.Unbind(EVT_MOTION, on_mouse_move)
-            canvas.Unbind(EVT_LEFT_DOWN, on_mouse_press)
-            canvas.Unbind(EVT_LEFT_UP, on_mouse_release)
-
-        return _unbind
-
-
-class JupyterProvider(GuiProvider):
-    """Provider for Jupyter notebooks/lab (NOT ipython)."""
-
-    @staticmethod
-    def is_running() -> bool:
-        if ipy_shell := _ipython_shell():
-            return bool(ipy_shell.__class__.__name__ == "ZMQInteractiveShell")
-        return False
-
-    @staticmethod
-    def create_app() -> Any:
-        if not JupyterProvider.is_running() and not os.getenv("PYTEST_CURRENT_TEST"):
-            # if we got here, it probably means that someone used
-            # NDV_GUI_FRONTEND=jupyter without actually being in a juptyer notebook
-            # we allow it in tests, but not in normal usage.
-            raise RuntimeError(  # pragma: no cover
-                "Jupyter is not running a notebook shell.  Cannot create app."
-            )
-        # No app creation needed...
-        # but make sure we can actually import the stuff we need
-        import ipywidgets  # noqa: F401
-        import jupyter  # noqa: F401
-        import jupyter_rfb  # noqa: F401
-
-    @staticmethod
-    def exec() -> None:
-        pass
-
-    @staticmethod
-    def array_view_class() -> type[ArrayView]:
-        from ._jupyter._array_view import JupyterArrayView
-
-        return JupyterArrayView
-
-    @staticmethod
-    def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]:
-        from jupyter_rfb import RemoteFrameBuffer
-
-        if not isinstance(canvas, RemoteFrameBuffer):
-            raise TypeError(
-                f"Expected canvas to be RemoteFrameBuffer, got {type(canvas)}"
-            )
-
-        # patch the handle_event from _jupyter_rfb.CanvasBackend
-        # to intercept various mouse events.
-        super_handle_event = canvas.handle_event
-
-        def handle_event(self: RemoteFrameBuffer, ev: dict) -> None:
-            etype = ev["event_type"]
-            if etype == "pointer_move":
-                mme = MouseMoveEvent(x=ev["x"], y=ev["y"])
-                receiver.on_mouse_move(mme)
-                receiver.mouseMoved.emit(mme)
-            elif etype == "pointer_down":
-                mpe = MousePressEvent(x=ev["x"], y=ev["y"])
-                receiver.on_mouse_press(mpe)
-                receiver.mousePressed.emit(mpe)
-            elif etype == "pointer_up":
-                mre = MouseReleaseEvent(x=ev["x"], y=ev["y"])
-                receiver.on_mouse_release(mre)
-                receiver.mouseReleased.emit(mre)
-            super_handle_event(ev)
-
-        canvas.handle_event = MethodType(handle_event, canvas)
-        return lambda: setattr(canvas, "handle_event", super_handle_event)
 
 
 class VispyProvider(CanvasProvider):
@@ -453,35 +128,55 @@ class PygfxProvider(CanvasProvider):
         raise RuntimeError("Histogram not supported for pygfx")
 
 
-def _ipython_shell() -> InteractiveShell | None:
-    if (ipy := sys.modules.get("IPython")) and (shell := ipy.get_ipython()):
-        return cast("InteractiveShell", shell)
-    return None
-
-
 # -------------------- Provider selection --------------------
 
 # list of available GUI frontends and canvas backends, tried in order
 
-GUI_PROVIDERS: dict[GuiFrontend, GuiProvider] = {
-    GuiFrontend.QT: QtProvider,
-    GuiFrontend.WX: WxProvider,
-    GuiFrontend.JUPYTER: JupyterProvider,
+GUI_PROVIDERS: dict[GuiFrontend, tuple[str, str]] = {
+    GuiFrontend.QT: ("ndv.views._qt._app", "QtAppWrap"),
+    GuiFrontend.WX: ("ndv.views._wx._app", "WxAppWrap"),
+    GuiFrontend.JUPYTER: ("ndv.views._jupyter._app", "JupyterAppWrap"),
 }
+MOD_TO_KEY = {mod: key for key, (mod, _) in GUI_PROVIDERS.items()}
 CANVAS_PROVIDERS: dict[CanvasBackend, CanvasProvider] = {
     CanvasBackend.VISPY: VispyProvider,
     CanvasBackend.PYGFX: PygfxProvider,
 }
 
 
+def running_apps() -> Iterator[GuiFrontend]:
+    for mod_name in ("PyQt5", "PySide2", "PySide6", "PyQt6"):
+        if mod := sys.modules.get(f"{mod_name}.QtWidgets"):
+            if (
+                qapp := getattr(mod, "QApplication", None)
+            ) and qapp.instance() is not None:
+                yield GuiFrontend.QT
+
+    if (wx := sys.modules.get("wx")) and wx.App.Get() is not None:
+        yield GuiFrontend.WX
+
+    if (ipy := sys.modules.get("IPython")) and (shell := ipy.get_ipython()):
+        shell = cast("InteractiveShell", shell)
+        if shell.__class__.__name__ == "ZMQInteractiveShell":
+            yield GuiFrontend.JUPYTER
+
+
+def _load_app(module: str, cls_name: str) -> NDVApp:
+    mod = importlib.import_module(module)
+    cls = getattr(mod, cls_name)
+    return cast(NDVApp, cls())
+
+
 @cache  # not allowed to change
-def gui_frontend() -> GuiFrontend:
+def ndv_app() -> NDVApp:
     """Return the active [`GuiFrontend`][ndv.views.GuiFrontend].
 
     This is determined first by the `NDV_GUI_FRONTEND` environment variable, after which
     known GUI providers are tried in order until one is found that is either already
     running, or available.
     """
+    running = list(running_apps())
+
     requested = os.getenv(GUI_ENV_VAR, "").lower()
     valid = {x.value for x in GuiFrontend}
     if requested:
@@ -489,29 +184,35 @@ def gui_frontend() -> GuiFrontend:
             raise ValueError(
                 f"Invalid GUI frontend: {requested!r}. Valid options: {valid}"
             )
-        key = GuiFrontend(requested)
         # ensure the app is created for explicitly requested frontends
-        provider = GUI_PROVIDERS[key]
-        if not provider.is_running():
-            provider.create_app()
-        return key
+        app = _load_app(*GUI_PROVIDERS[GuiFrontend(requested)])
+        app.create_app()
+        return app
 
     for key, provider in GUI_PROVIDERS.items():
-        if provider.is_running():
-            return key
+        if key in running:
+            app = _load_app(*provider)
+            app.create_app()
+            return app
 
-    errors: list[tuple[GuiFrontend, BaseException]] = []
+    errors: list[tuple[str, BaseException]] = []
     for key, provider in GUI_PROVIDERS.items():
         try:
-            provider.create_app()
-            return key
+            app = _load_app(*provider)
+            app.create_app()
+            return app
         except Exception as e:
             errors.append((key, e))
 
     raise RuntimeError(  # pragma: no cover
         f"Could not find an appropriate GUI frontend: {valid!r}. Tried:\n\n"
-        + "\n".join(f"- {key.value}: {err}" for key, err in errors)
+        + "\n".join(f"- {key}: {err}" for key, err in errors)
     )
+
+
+def gui_frontend() -> GuiFrontend:
+    # possibly temporary hack to get the current frontend as an enum, for back-compat
+    return MOD_TO_KEY[ndv_app().__module__]
 
 
 def canvas_backend(requested: str | None) -> CanvasBackend:
@@ -548,11 +249,9 @@ def canvas_backend(requested: str | None) -> CanvasBackend:
     )
 
 
-# TODO: add a way to set the frontend via an environment variable
-# (for example, it should be possible to use qt frontend in a jupyter notebook)
 def get_array_view_class() -> type[ArrayView]:
     """Return [`ArrayView`][ndv.views.bases.ArrayView] class for current GUI frontend."""  # noqa: E501
-    return GUI_PROVIDERS[gui_frontend()].array_view_class()
+    return ndv_app().array_view_class()
 
 
 def get_array_canvas_class(backend: str | None = None) -> type[ArrayCanvas]:
@@ -586,84 +285,12 @@ def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]:
     Callable[[], None]
         A function that can be called to remove the event filter.
     """
-    return GUI_PROVIDERS[gui_frontend()].filter_mouse_events(canvas, receiver)
+    return ndv_app().filter_mouse_events(canvas, receiver)
 
 
 def run_app() -> None:
     """Start the active GUI application event loop."""
-    GUI_PROVIDERS[gui_frontend()].exec()
-
-
-# -------------------- Exception handling --------------------
-
-
-def _install_excepthook() -> None:
-    """Install a custom excepthook that does not raise sys.exit().
-
-    This is necessary to prevent the application from closing when an exception
-    is raised.
-    """
-    if hasattr(sys, "_original_excepthook_"):
-        # don't install the excepthook more than once
-        return
-    sys._original_excepthook_ = sys.excepthook  # type: ignore
-    sys.excepthook = ndv_excepthook
-
-
-def _print_exception(
-    exc_type: type[BaseException],
-    exc_value: BaseException,
-    exc_traceback: TracebackType | None,
-) -> None:
-    try:
-        import psygnal
-        from rich.console import Console
-        from rich.traceback import Traceback
-
-        tb = Traceback.from_exception(
-            exc_type, exc_value, exc_traceback, suppress=[psygnal], max_frames=10
-        )
-        Console(stderr=True).print(tb)
-    except ImportError:
-        traceback.print_exception(exc_type, value=exc_value, tb=exc_traceback)
-
-
-def ndv_excepthook(
-    exc_type: type[BaseException], exc_value: BaseException, tb: TracebackType | None
-) -> None:
-    _print_exception(exc_type, exc_value, tb)
-    if not tb:
-        return
-
-    if (
-        (debugpy := sys.modules.get("debugpy"))
-        and debugpy.is_client_connected()
-        and ("pydevd" in sys.modules)
-    ):
-        with suppress(Exception):
-            import threading
-
-            import pydevd
-
-            py_db = pydevd.get_global_debugger()
-            thread = threading.current_thread()
-            additional_info = py_db.set_additional_thread_info(thread)
-            additional_info.is_tracing += 1
-
-            try:
-                arg = (exc_type, exc_value, tb)
-                py_db.stop_on_unhandled_exception(py_db, thread, additional_info, arg)
-            finally:
-                additional_info.is_tracing -= 1
-    elif os.getenv(DEBUG_EXCEPTIONS) in ("1", "true", "True"):
-        # Default to pdb if no better option is available
-        import pdb
-
-        pdb.post_mortem(tb)
-
-    if os.getenv(EXIT_ON_EXCEPTION) in ("1", "true", "True"):
-        print(f"\n{EXIT_ON_EXCEPTION} is set, exiting.")
-        sys.exit(1)
+    ndv_app().run()
 
 
 def ensure_main_thread(func: Callable[P, T]) -> Callable[P, Future[T]]:
@@ -671,7 +298,7 @@ def ensure_main_thread(func: Callable[P, T]) -> Callable[P, Future[T]]:
 
     @wraps(func)
     def _wrapper(*args: P.args, **kwargs: P.kwargs) -> Future[T]:
-        fn = GUI_PROVIDERS[gui_frontend()].call_in_main_thread
+        fn = ndv_app().call_in_main_thread
         return fn(func, *args, **kwargs)
 
     return _wrapper
@@ -683,5 +310,5 @@ def submit_task(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Futu
     Returns a `concurrent.futures.Future` or an `asyncio.Future` depending on the
     GUI frontend.
     """
-    executor = GUI_PROVIDERS[gui_frontend()].get_executor()
+    executor = ndv_app().get_executor()
     return executor.submit(func, *args, **kwargs)

--- a/src/ndv/views/_jupyter/_app.py
+++ b/src/ndv/views/_jupyter/_app.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from types import MethodType
+from typing import TYPE_CHECKING, Any, Callable
+
+from jupyter_rfb import RemoteFrameBuffer
+
+from ndv._types import MouseMoveEvent, MousePressEvent, MouseReleaseEvent
+from ndv.views.bases._app import NDVApp
+
+if TYPE_CHECKING:
+    from ndv.views.bases import ArrayView
+    from ndv.views.bases._graphics._mouseable import Mouseable
+
+
+class JupyterAppWrap(NDVApp):
+    """Provider for Jupyter notebooks/lab (NOT ipython)."""
+
+    def is_running(self) -> bool:
+        if ipy_shell := self._ipython_shell():
+            return bool(ipy_shell.__class__.__name__ == "ZMQInteractiveShell")
+        return False
+
+    def create_app(self) -> Any:
+        if not self.is_running() and not os.getenv("PYTEST_CURRENT_TEST"):
+            # if we got here, it probably means that someone used
+            # NDV_GUI_FRONTEND=jupyter without actually being in a juptyer notebook
+            # we allow it in tests, but not in normal usage.
+            raise RuntimeError(  # pragma: no cover
+                "Jupyter is not running a notebook shell.  Cannot create app."
+            )
+
+        # No app creation needed...
+        # but make sure we can actually import the stuff we need
+        import ipywidgets  # noqa: F401
+        import jupyter  # noqa: F401
+
+    def array_view_class(self) -> type[ArrayView]:
+        from ._array_view import JupyterArrayView
+
+        return JupyterArrayView
+
+    def filter_mouse_events(
+        self, canvas: Any, receiver: Mouseable
+    ) -> Callable[[], None]:
+        if not isinstance(canvas, RemoteFrameBuffer):
+            raise TypeError(
+                f"Expected canvas to be RemoteFrameBuffer, got {type(canvas)}"
+            )
+
+        # patch the handle_event from _jupyter_rfb.CanvasBackend
+        # to intercept various mouse events.
+        super_handle_event = canvas.handle_event
+
+        def handle_event(self: RemoteFrameBuffer, ev: dict) -> None:
+            etype = ev["event_type"]
+            if etype == "pointer_move":
+                mme = MouseMoveEvent(x=ev["x"], y=ev["y"])
+                receiver.on_mouse_move(mme)
+                receiver.mouseMoved.emit(mme)
+            elif etype == "pointer_down":
+                mpe = MousePressEvent(x=ev["x"], y=ev["y"])
+                receiver.on_mouse_press(mpe)
+                receiver.mousePressed.emit(mpe)
+            elif etype == "pointer_up":
+                mre = MouseReleaseEvent(x=ev["x"], y=ev["y"])
+                receiver.on_mouse_release(mre)
+                receiver.mouseReleased.emit(mre)
+            super_handle_event(ev)
+
+        canvas.handle_event = MethodType(handle_event, canvas)
+        return lambda: setattr(canvas, "handle_event", super_handle_event)

--- a/src/ndv/views/_qt/_app.py
+++ b/src/ndv/views/_qt/_app.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
+
+from qtpy.QtCore import QEvent, QObject
+from qtpy.QtGui import QMouseEvent
+from qtpy.QtWidgets import QApplication
+
+from ndv._types import MouseMoveEvent, MousePressEvent, MouseReleaseEvent
+from ndv.views.bases._app import NDVApp
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+    from concurrent.futures import Future
+
+    from ndv.views.bases import ArrayView
+    from ndv.views.bases._app import P, T
+    from ndv.views.bases._graphics._mouseable import Mouseable
+
+
+class QtAppWrap(NDVApp):
+    """Provider for PyQt5/PySide2/PyQt6/PySide6."""
+
+    _APP_INSTANCE: ClassVar[Any] = None
+    IPY_MAGIC_KEY = "qt"
+
+    def create_app(self) -> Any:
+        if (qapp := QApplication.instance()) is None:
+            # if we're running in IPython
+            # start the %gui qt magic if NDV_IPYTHON_MAGIC!=0
+            if not self._maybe_enable_ipython_gui():
+                # otherwise create a new QApplication
+                # must be stored in a class variable to prevent garbage collection
+                QtAppWrap._APP_INSTANCE = qapp = QApplication(sys.argv)
+                qapp.setOrganizationName("ndv")
+                qapp.setApplicationName("ndv")
+
+        self._install_excepthook()
+        return qapp
+
+    def run(self) -> None:
+        app = QApplication.instance() or self.create_app()
+
+        for wdg in QApplication.topLevelWidgets():
+            wdg.raise_()
+
+        if ipy_shell := self._ipython_shell():
+            # if we're already in an IPython session with %gui qt, don't block
+            if str(ipy_shell.active_eventloop).startswith("qt"):
+                return
+
+        app.exec()
+
+    def call_in_main_thread(
+        self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+    ) -> Future[T]:
+        from ._main_thread import call_in_main_thread
+
+        return call_in_main_thread(func, *args, **kwargs)
+
+    def array_view_class(self) -> type[ArrayView]:
+        from ._array_view import QtArrayView
+
+        return QtArrayView
+
+    def filter_mouse_events(
+        self, canvas: Any, receiver: Mouseable
+    ) -> Callable[[], None]:
+        if not isinstance(canvas, QObject):
+            raise TypeError(f"Expected canvas to be QObject, got {type(canvas)}")
+
+        f = MouseEventFilter(canvas, receiver)
+        canvas.installEventFilter(f)
+        return lambda: canvas.removeEventFilter(f)
+
+
+class MouseEventFilter(QObject):
+    def __init__(self, canvas: QObject, receiver: Mouseable):
+        super().__init__()
+        self.canvas = canvas
+        self.receiver = receiver
+
+    def eventFilter(self, obj: QObject | None, qevent: QEvent | None) -> bool:
+        """Event filter installed on the canvas to handle mouse events.
+
+        here is where we get a chance to intercept mouse events before allowing
+        the canvas to respond to them. Return `True` to prevent the event from
+        being passed to the canvas.
+        """
+        if qevent is None:
+            return False  # pragma: no cover
+
+        try:
+            # use children in case backend has a subwidget stealing events.
+            children: Container = self.canvas.children()
+        except RuntimeError:
+            # native is likely dead
+            return False
+
+        intercept = False
+        receiver = self.receiver
+        if obj is self.canvas or obj in children:
+            if isinstance(qevent, QMouseEvent):
+                pos = qevent.pos()
+                etype = qevent.type()
+                if etype == QEvent.Type.MouseMove:
+                    mme = MouseMoveEvent(x=pos.x(), y=pos.y())
+                    intercept |= receiver.on_mouse_move(mme)
+                    receiver.mouseMoved.emit(mme)
+                elif etype == QEvent.Type.MouseButtonPress:
+                    mpe = MousePressEvent(x=pos.x(), y=pos.y())
+                    intercept |= receiver.on_mouse_press(mpe)
+                    receiver.mousePressed.emit(mpe)
+                elif etype == QEvent.Type.MouseButtonRelease:
+                    mre = MouseReleaseEvent(x=pos.x(), y=pos.y())
+                    intercept |= receiver.on_mouse_release(mre)
+                    receiver.mouseReleased.emit(mre)
+        return intercept

--- a/src/ndv/views/_wx/_app.py
+++ b/src/ndv/views/_wx/_app.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+import wx
+from wx import EVT_LEFT_DOWN, EVT_LEFT_UP, EVT_MOTION, EvtHandler, MouseEvent
+
+from ndv._types import MouseMoveEvent, MousePressEvent, MouseReleaseEvent
+from ndv.views.bases._app import NDVApp
+
+from ._main_thread import call_in_main_thread
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future
+
+    from ndv.views.bases import ArrayView
+    from ndv.views.bases._app import P, T
+    from ndv.views.bases._graphics._mouseable import Mouseable
+
+
+class WxAppWrap(NDVApp):
+    """Provider for wxPython."""
+
+    IPY_MAGIC_KEY = "wx"
+
+    def create_app(self) -> Any:
+        if (wxapp := wx.App.Get()) is None:
+            wxapp = wx.App()
+
+        self._maybe_enable_ipython_gui()
+        self._install_excepthook()
+        return wxapp
+
+    def run(self) -> None:
+        app = wx.App.Get() or self.create_app()
+
+        if ipy_shell := self._ipython_shell():
+            # if we're already in an IPython session with %gui qt, don't block
+            if str(ipy_shell.active_eventloop).startswith("wx"):
+                return
+
+        app.MainLoop()
+
+    def call_in_main_thread(
+        self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+    ) -> Future[T]:
+        return call_in_main_thread(func, *args, **kwargs)
+
+    def array_view_class(self) -> type[ArrayView]:
+        from ._array_view import WxArrayView
+
+        return WxArrayView
+
+    def filter_mouse_events(
+        self, canvas: Any, receiver: Mouseable
+    ) -> Callable[[], None]:
+        if not isinstance(canvas, EvtHandler):
+            raise TypeError(
+                f"Expected vispy canvas to be wx EvtHandler, got {type(canvas)}"
+            )
+
+        # TIP: event.Skip() allows the event to propagate to other handlers.
+
+        def on_mouse_move(event: MouseEvent) -> None:
+            mme = MouseMoveEvent(x=event.GetX(), y=event.GetY())
+            if not receiver.on_mouse_move(mme):
+                receiver.mouseMoved.emit(mme)
+                event.Skip()
+
+        def on_mouse_press(event: MouseEvent) -> None:
+            mpe = MousePressEvent(x=event.GetX(), y=event.GetY())
+            if not receiver.on_mouse_press(mpe):
+                receiver.mousePressed.emit(mpe)
+                event.Skip()
+
+        def on_mouse_release(event: MouseEvent) -> None:
+            mre = MouseReleaseEvent(x=event.GetX(), y=event.GetY())
+            if not receiver.on_mouse_release(mre):
+                receiver.mouseReleased.emit(mre)
+                event.Skip()
+
+        canvas.Bind(EVT_MOTION, on_mouse_move)
+        canvas.Bind(EVT_LEFT_DOWN, on_mouse_press)
+        canvas.Bind(EVT_LEFT_UP, on_mouse_release)
+
+        def _unbind() -> None:
+            canvas.Unbind(EVT_MOTION, on_mouse_move)
+            canvas.Unbind(EVT_LEFT_DOWN, on_mouse_press)
+            canvas.Unbind(EVT_LEFT_UP, on_mouse_release)
+
+        return _unbind

--- a/src/ndv/views/bases/__init__.py
+++ b/src/ndv/views/bases/__init__.py
@@ -1,5 +1,6 @@
 """Abstract base classes for views and viewable objects."""
 
+from ._app import NDVApp
 from ._array_view import ArrayView
 from ._graphics._canvas import ArrayCanvas, HistogramCanvas
 from ._graphics._canvas_elements import CanvasElement, ImageHandle, RoiHandle
@@ -15,6 +16,7 @@ __all__ = [
     "ImageHandle",
     "LutView",
     "Mouseable",
+    "NDVApp",
     "RoiHandle",
     "Viewable",
 ]

--- a/src/ndv/views/bases/_app.py
+++ b/src/ndv/views/bases/_app.py
@@ -31,28 +31,33 @@ class NDVApp:
     # must be valid key for %gui <magic> in IPython
     IPY_MAGIC_KEY: ClassVar[Literal["qt", "wx", None]] = None
 
-    def create_app(self) -> bool:
+    def create_app(self) -> Any:
+        """Create the application instance, if not already created."""
         raise NotImplementedError
 
     def array_view_class(self) -> type[ArrayView]:
         raise NotImplementedError
 
     def run(self) -> None:
+        """Run the application."""
         pass
 
     def filter_mouse_events(
         self, canvas: Any, receiver: Mouseable
     ) -> Callable[[], None]:
+        """Install mouse event filter on `canvas`, redirecting events to `receiver`."""
         raise NotImplementedError
 
     def call_in_main_thread(
         self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> Future[T]:
+        """Call `func` in the main gui thread."""
         future: Future[T] = Future()
         future.set_result(func(*args, **kwargs))
         return future
 
     def get_executor(self) -> Executor:
+        """Return an executor for running tasks in the background."""
         return _thread_pool_executor()
 
     @staticmethod

--- a/src/ndv/views/bases/_app.py
+++ b/src/ndv/views/bases/_app.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from contextlib import suppress
+from functools import cache
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, cast
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from IPython.core.interactiveshell import InteractiveShell
+    from typing_extensions import ParamSpec, TypeVar
+
+    from ndv.views.bases import ArrayView
+    from ndv.views.bases._graphics._mouseable import Mouseable
+
+    T = TypeVar("T")
+    P = ParamSpec("P")
+
+ENV_IPYTHON_GUI_MAGIC = os.getenv("NDV_IPYTHON_MAGIC", "true").lower()
+"""Whether to use %gui magic when running in IPython. Default True."""
+
+
+class NDVApp:
+    """Base class for application wrappers."""
+
+    USE_IPY_MAGIC = ENV_IPYTHON_GUI_MAGIC not in ("0", "false", "no")
+    # must be valid key for %gui <magic> in IPython
+    IPY_MAGIC_KEY: ClassVar[Literal["qt", "wx", None]] = None
+
+    def create_app(self) -> bool:
+        raise NotImplementedError
+
+    def array_view_class(self) -> type[ArrayView]:
+        raise NotImplementedError
+
+    def run(self) -> None:
+        pass
+
+    def filter_mouse_events(
+        self, canvas: Any, receiver: Mouseable
+    ) -> Callable[[], None]:
+        raise NotImplementedError
+
+    def call_in_main_thread(
+        self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+    ) -> Future[T]:
+        future: Future[T] = Future()
+        future.set_result(func(*args, **kwargs))
+        return future
+
+    def get_executor(self) -> Executor:
+        return _thread_pool_executor()
+
+    @staticmethod
+    def _ipython_shell() -> InteractiveShell | None:
+        if (ipy := sys.modules.get("IPython")) and (shell := ipy.get_ipython()):
+            return cast("InteractiveShell", shell)
+        return None
+
+    def _maybe_enable_ipython_gui(self) -> bool:
+        if (
+            (ipy_shell := self._ipython_shell())
+            and self.USE_IPY_MAGIC
+            and (key := self.IPY_MAGIC_KEY)
+        ):
+            ipy_shell.enable_gui(key)  # type: ignore [no-untyped-call]
+            return True
+        return False
+
+    @staticmethod
+    def _install_excepthook() -> None:
+        """Install a custom excepthook that does not raise sys.exit().
+
+        This is necessary to prevent the application from closing when an exception
+        is raised.
+        """
+        if hasattr(sys, "_original_excepthook_"):
+            # don't install the excepthook more than once
+            return
+        sys._original_excepthook_ = sys.excepthook  # type: ignore
+        sys.excepthook = ndv_excepthook
+
+
+@cache
+def _thread_pool_executor() -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(max_workers=2)
+
+
+# -------------------- Exception handling --------------------
+DEBUG_EXCEPTIONS = "NDV_DEBUG_EXCEPTIONS"
+"""Whether to drop into a debugger when an exception is raised. Default False."""
+
+EXIT_ON_EXCEPTION = "NDV_EXIT_ON_EXCEPTION"
+"""Whether to exit the application when an exception is raised. Default False."""
+
+
+def _print_exception(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: TracebackType | None,
+) -> None:
+    try:
+        import psygnal
+        from rich.console import Console
+        from rich.traceback import Traceback
+
+        tb = Traceback.from_exception(
+            exc_type, exc_value, exc_traceback, suppress=[psygnal], max_frames=10
+        )
+        Console(stderr=True).print(tb)
+    except ImportError:
+        traceback.print_exception(exc_type, value=exc_value, tb=exc_traceback)
+
+
+def ndv_excepthook(
+    exc_type: type[BaseException], exc_value: BaseException, tb: TracebackType | None
+) -> None:
+    _print_exception(exc_type, exc_value, tb)
+    if not tb:
+        return
+
+    if (
+        (debugpy := sys.modules.get("debugpy"))
+        and debugpy.is_client_connected()
+        and ("pydevd" in sys.modules)
+    ):
+        with suppress(Exception):
+            import threading
+
+            import pydevd
+
+            py_db = pydevd.get_global_debugger()
+            thread = threading.current_thread()
+            additional_info = py_db.set_additional_thread_info(thread)
+            additional_info.is_tracing += 1
+
+            try:
+                arg = (exc_type, exc_value, tb)
+                py_db.stop_on_unhandled_exception(py_db, thread, additional_info, arg)
+            finally:
+                additional_info.is_tracing -= 1
+    elif os.getenv(DEBUG_EXCEPTIONS) in ("1", "true", "True"):
+        # Default to pdb if no better option is available
+        import pdb
+
+        pdb.post_mortem(tb)
+
+    if os.getenv(EXIT_ON_EXCEPTION) in ("1", "true", "True"):
+        print(f"\n{EXIT_ON_EXCEPTION} is set, exiting.")
+        sys.exit(1)


### PR DESCRIPTION
this is a bit of a reversal of #75 ... but probably much better than the state of things before #75.

basically: trying to get all the gui-specific stuff back into their own folders.  This creates a base NDVapp class that GUI frameworks have to implement to be supported.  (its the same as the current `GUIProvider` object).

it does move a little bit of logic for each framework *back* into `_app.py`, mostly the "is_running" logic.  but by having just that logic there, it allows all the rest to go back to the proper folder


this also fixes a bug wherein if you explicitly use `NDV_GUI_FRONTEND=qt` inside a jupyter notebook. it still doesn't let you use a Qt widget.