### PR TITLE
docs: make all scripts pep 723 compliant

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Examples
+
+To quickly run any of the examples in this directory, without needing to install
+either ndv or even python, you can [install
+uv](https://docs.astral.sh/uv/getting-started/installation/), and then use [`uv
+run`](https://docs.astral.sh/uv/guides/scripts/):
+
+```shell
+# locally within the ndv repo
+uv run examples/numpy_arr.py
+
+# from anywhere
+uv run https://github.com/pyapp-kit/ndv/raw/refs/heads/main/examples/numpy_arr.py
+```
+
+Replace `numpy_arr.py` with the name of the example file in this directory you
+want to run.
+
+## Notbooks
+
+To run any of the `.ipynb` files in this directory, you can use uv with
+[`juv`](https://github.com/manzt/juv)
+
+```shell
+uvx juv run examples/notebook.ipynb
+```
+
+*At the time of writing, juv only appears to support local files, so you should
+clone this repo first.*

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ uv run https://github.com/pyapp-kit/ndv/raw/refs/heads/main/examples/numpy_arr.p
 Replace `numpy_arr.py` with the name of the example file in this directory you
 want to run.
 
-## Notbooks
+## Notebooks
 
 To run any of the `.ipynb` files in this directory, you can use uv with
 [`juv`](https://github.com/manzt/juv)

--- a/examples/dask_arr.py
+++ b/examples/dask_arr.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "dask[array]",
+# ]
+# ///
 from __future__ import annotations
 
 import numpy as np

--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -2,6 +2,26 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "aa695816",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# /// script\n",
+    "# requires-python = \">=3.10\"\n",
+    "# dependencies = [\n",
+    "#     \"imageio[tifffile]\",\n",
+    "#     \"ndv[jupyter,vispy]\",\n",
+    "# ]\n",
+    "# ///"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "461399b0-e02d-43d9-9ede-c1aa6c180338",
    "metadata": {},
@@ -9,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "29a311147df1426dabd6ecda111c075b",
+       "model_id": "61c74e75ad264c2d954595f4b310f649",
        "version_major": 2,
        "version_minor": 0
       },
@@ -23,7 +43,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f76754302d514472af1810231a08aeff",
+       "model_id": "1fa995f6b1c4423aa24e73b9c4ce29f0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -67,7 +87,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -81,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/examples/numpy_arr.py
+++ b/examples/numpy_arr.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "imageio[tifffile]",
+# ]
+# ///
 from __future__ import annotations
 
 import ndv

--- a/examples/pyopencl_arr.py
+++ b/examples/pyopencl_arr.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "pyopencl",
+#     "siphash24",
+# ]
+# ///
 from __future__ import annotations
 
 try:

--- a/examples/sparse_arr.py
+++ b/examples/sparse_arr.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "sparse",
+# ]
+# ///
 from __future__ import annotations
 
 try:
@@ -9,10 +15,10 @@ import numpy as np
 
 import ndv
 
-shape = (256, 4, 512, 512)
+shape = (255, 4, 512, 512)
 N = int(np.prod(shape) * 0.001)
-coords = np.random.randint(low=0, high=shape, size=(N, len(shape))).T
-data = np.random.randint(0, 256, N)
+coords = np.random.randint(low=0, high=shape, size=(N, len(shape)), dtype=np.uint16).T
+data = np.random.randint(0, 255, N, dtype=np.uint8)
 
 
 # Create the sparse array from the coordinates and data

--- a/examples/tensorstore_arr.py
+++ b/examples/tensorstore_arr.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "tensorstore",
+# ]
+# ///
 from __future__ import annotations
 
 import ndv

--- a/examples/torch_arr.py
+++ b/examples/torch_arr.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "torch>=2.5",
+# ]
+# ///
 from __future__ import annotations
 
 try:

--- a/examples/xarray_arr.py
+++ b/examples/xarray_arr.py
@@ -1,3 +1,11 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "xarray",
+#     "scipy",
+#     "pooch",
+# ]
+# ///
 from __future__ import annotations
 
 try:

--- a/examples/zarr_arr.py
+++ b/examples/zarr_arr.py
@@ -1,3 +1,11 @@
+# /// script
+# dependencies = [
+#     "ndv[pyqt,vispy]",
+#     "zarr",
+#     "fsspec",
+#     "aiohttp",
+# ]
+# ///
 from __future__ import annotations
 
 import ndv


### PR DESCRIPTION
This PR makes all of our examples [pep 723](https://peps.python.org/pep-0723/) compliant

which has the very cool side effect of support `uv run` and `pipx run`.  For example, to run the ndv tensorstore example, starting with *no* assumptions about the python version or environment installed on the users computer:

```sh
https://raw.githubusercontent.com/tlambert03/ndv/refs/heads/pep-723/examples/tensorstore_arr.py
```