### PR TITLE
Add mechanism to generate screenshot from examples, and build during docs

### DIFF
--- a/docs/cookbook/embedding.md
+++ b/docs/cookbook/embedding.md
@@ -11,7 +11,7 @@ The following script shows an example on how to dynamically select a data set an
 --8<-- "examples/cookbook/ndv_embedded.py"
 ````
 
-![Screenshot generated from ndv_embedded.py](../screenshots/cookbook/ndv_embedded.png)
+![Screenshot generated from ndv_embedded.py](../screenshots/cookbook/ndv_embedded.png) {: .screenshot }
 
 ## Use multiple `ndv.ArrayViewer` controllers in the same widget
 

--- a/docs/cookbook/embedding.md
+++ b/docs/cookbook/embedding.md
@@ -3,13 +3,15 @@
 `ndv` can be embedded in an existing Qt application and enriched with additional elements in a custom layout.
 The following document shows some examples of such implementation.
 
-## Change the content of `ArrayViewer` via push buttons.
+## Change the content of `ArrayViewer` via push buttons
 
 The following script shows an example on how to dynamically select a data set and load it in the `ArrayViewer`.
 
 ````python title="examples/cookbook/ndv_embedded.py"
 --8<-- "examples/cookbook/ndv_embedded.py"
 ````
+
+![Screenshot generated from ndv_embedded.py](../screenshots/cookbook/ndv_embedded.png)
 
 ## Use multiple `ndv.ArrayViewer` controllers in the same widget
 

--- a/docs/scripts/gen_ref_nav.py
+++ b/docs/scripts/gen_ref_nav.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import mkdocs_gen_files
 
+FE = mkdocs_gen_files.editor.FilesEditor.current()
 nav = mkdocs_gen_files.Nav()
 mod_symbol = '<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code>'
 
@@ -27,11 +28,11 @@ for path in sorted(SRC.rglob("*.py")):
     nav_parts = [f"{mod_symbol} {part}" for part in parts]
     nav[tuple(nav_parts)] = doc_path.as_posix()
 
-    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+    with FE.open(str(full_doc_path), "w") as fd:
         ident = ".".join(parts)
         fd.write(f"---\ntitle: {ident}\n---\n\n::: {ident}")
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path.relative_to(ROOT))
+    FE.set_edit_path(str(full_doc_path), str(".." / path.relative_to(ROOT)))
 
-with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+with FE.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/docs/scripts/gen_screenshots.py
+++ b/docs/scripts/gen_screenshots.py
@@ -1,0 +1,120 @@
+import io
+import runpy
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Any, BinaryIO, cast, overload
+from unittest.mock import patch
+
+from qtpy.QtCore import QBuffer, QIODevice
+from qtpy.QtWidgets import QApplication
+
+
+@overload
+def generate_screenshot(script: Path, output: BinaryIO) -> BinaryIO: ...
+@overload
+def generate_screenshot(script: Path, output: Path | None = ...) -> Path: ...
+def generate_screenshot(
+    script: Path, output: Path | BinaryIO | None = None
+) -> Path | BinaryIO:
+    """Generate a screenshot from a script."""
+    script = Path(script).resolve()
+    if not script.is_file():
+        raise FileNotFoundError(f"File not found: {script}")
+    if script.suffix != ".py":
+        raise ValueError(f"Invalid file type: {script}")
+
+    if output is None:
+        output = script.with_suffix(".png")
+    if isinstance(output, Path):
+        output.parent.mkdir(parents=True, exist_ok=True)
+    elif not isinstance(output, io.BufferedWriter):
+        raise TypeError(
+            f"output must be a Path or file-like object, not {type(output)}"
+        )
+
+    # run
+    with patch.object(QApplication, "exec", partial(snap_viewer, output=output)):
+        runpy.run_path(str(script), run_name="__main__")
+
+    return output
+
+
+def snap_viewer(*_: Any, output: Path | BinaryIO) -> None:
+    """Mock QApplication.exec that snaps a screenshot and exits without blocking."""
+    from ndv.views._qt._array_view import _QArrayViewer
+
+    try:
+        qviewer = next(
+            wdg
+            for wdg in QApplication.topLevelWidgets()
+            if isinstance(wdg, _QArrayViewer)
+        )
+    except StopIteration:
+        return
+
+    target: str | QIODevice
+    if isinstance(output, io.BufferedWriter):
+        target = QBuffer()
+        target.open(QIODevice.OpenModeFlag.WriteOnly)
+    else:
+        target = str(output)
+
+    QApplication.sendPostedEvents()
+    QApplication.processEvents()
+
+    qviewer.grab().save(target)
+    if isinstance(target, QBuffer):
+        img_bytes = target.data().data()
+        cast(BinaryIO, output).write(img_bytes)
+
+    for wdg in QApplication.topLevelWidgets():
+        wdg.close()
+        wdg.deleteLater()
+    QApplication.processEvents()
+
+
+# In this block, we're likely being run by mkdocs_gen_files
+# to generate screenshots for the documentation.
+# See extra.screenshots in mkdocs.yml for configuration to include/exclude
+if __name__ == "<run_path>":
+    import mkdocs_gen_files
+    from mkdocs.plugins import get_plugin_logger
+
+    logger = get_plugin_logger("gen_screenshots.py")
+    FE = mkdocs_gen_files.editor.FilesEditor.current()
+    examples_dir = Path(__file__).parent.parent.parent / "examples"
+    screenshots_dir = Path("screenshots")  # virtual directory inside of docs
+    cfg: dict = FE.config.get("extra", {}).get("screenshots", {})  # type: ignore
+    suffix = cfg.get("suffix", ".png")
+    scripts = sorted(examples_dir.rglob("*.py"))
+    if includes := cfg.get("include_patterns", []):
+        scripts = [ex for ex in scripts if any(ex.match(inc) for inc in includes)]
+        if includes and not scripts:
+            logger.warning(
+                "No scripts found with the patterns in "
+                f"extra.screenshots.include_patterns: {includes!r}",
+            )
+            sys.exit(0)
+
+    if excludes := cfg.get("exclude_patterns", []):
+        scripts = [ex for ex in scripts if not any(ex.match(exc) for exc in excludes)]
+
+    for script in scripts:
+        rel_path = script.relative_to(examples_dir)
+        script_screenshot_path = screenshots_dir / rel_path.with_suffix(suffix)
+        with FE.open(str(script_screenshot_path), "wb") as fd:
+            try:
+                generate_screenshot(script, output=fd)
+            except Exception as e:
+                get_plugin_logger("gen_screenshots.py").warning(
+                    f"Error generating screenshot for {script}: {e}"
+                )
+            else:
+                relpath = script.relative_to(examples_dir.parent)
+                logger.info(f"Generated screenshot for {relpath} to {fd.name}")
+
+
+elif __name__ == "__main__":
+    script = Path(__file__).parent.parent.parent / "examples" / "numpy_arr.py"
+    screenshot = generate_screenshot(script)

--- a/examples/cookbook/microscope_dashboard.py
+++ b/examples/cookbook/microscope_dashboard.py
@@ -64,7 +64,10 @@ class SyntheticManager(QObject):
             shape=camera_resolution,
         )
 
-        self._timer.timeout.connect(lambda: self.sigNewFrame.emit(self._camera.read()))
+        self._timer.timeout.connect(self.emit_frame)
+
+    def emit_frame(self) -> None:
+        self.sigNewFrame.emit(self._camera.read())
 
     def toggle_simulation(self, start: bool) -> None:
         if start:
@@ -191,6 +194,6 @@ wrapper = DashboardWidget()
 manager.sigNewFrame.connect(wrapper.new_frame)
 wrapper.sigSimStarted.connect(manager.toggle_simulation)
 wrapper.sigMoveStage.connect(manager.move_stage)
-
+manager.emit_frame()
 wrapper.show()
 app.exec()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ extra_javascript:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.keys
   - pymdownx.tilde

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,8 @@ plugins:
       cache_safe: true
   - gen-files:
       scripts:
-        - scripts/gen_ref_nav.py
+        - docs/scripts/gen_ref_nav.py
+        - docs/scripts/gen_screenshots.py
   - literate-nav:
       nav_file: SUMMARY.md
   - spellcheck:
@@ -145,6 +146,12 @@ hooks:
   - docs/hooks.py
 
 extra:
+  screenshots:
+    suffix: .png
+    # list of pathlib-patterns to include/exclude from autogeneration of screenshots
+    # https://docs.python.org/3/library/pathlib.html#pathlib-pattern-language
+    exclude_patterns: ['**/backend_test/**']
+    include_patterns: ['**/cookbook/**']
   version:
     provider: mike
   # either of these tags will enable the "viewing pre" announcement banner


### PR DESCRIPTION
follow up on #123  (cc @jacopoabramo), this adds a mechanism to run a script, and capture the output to a buffer that gets written to a temporary directory used by mkdocs.  allowing us to embed screenshots based on included examples in the documentation.

still some Qt bugs to iron out (which may require modificiations to the scripts themselves)