### PR TITLE
fix: don't _update_visible_sliders if there is no data

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -331,6 +331,8 @@ class ArrayViewer:
 
     def _update_visible_sliders(self) -> None:
         """Update which sliders are visible based on the current data and model."""
+        if self._data_model.data_wrapper is None:
+            return
         hidden_indices: set[int] = set(self._data_model.normed_visible_axes)
         if self._data_model.display.channel_mode.is_multichannel():
             if ch := self._data_model.normed_channel_axis:


### PR DESCRIPTION
fixes small avoidable bug when changing the channel mode combo box without data:


```
    /Users/talley/dev/self/ndv/src/ndv/controllers/_array_viewer.py:328 in _on_view_channel_mode_changed
      self._data_model.display.channel_mode = mode  # <-- SIGNAL WAS EMITTED HERE

  CALLBACK CHAIN:
    /Users/talley/dev/self/ndv/src/ndv/controllers/_array_viewer.py:279 in _on_model_channel_mode_changed
    ... 2 more frames ...
    /Users/talley/dev/self/ndv/src/ndv/models/_data_display_model.py:104 in _ensure_wrapper
      raise ValueError("Cannot normalize axes.  No data is set.")  # <-- ERROR OCCURRED HERE

```