### PR TITLE
fix: fix conditional when normalized channel axis resolves to 0

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -335,7 +335,7 @@ class ArrayViewer:
             return
         hidden_indices: set[int] = set(self._data_model.normed_visible_axes)
         if self._data_model.display.channel_mode.is_multichannel():
-            if ch := self._data_model.normed_channel_axis:
+            if (ch := self._data_model.normed_channel_axis) is not None:
                 hidden_indices.add(ch)
 
         # hide singleton axes

--- a/src/ndv/models/_data_display_model.py
+++ b/src/ndv/models/_data_display_model.py
@@ -200,7 +200,7 @@ class _ArrayDataDisplayModel(NDVModel):
 
         # if we need to request multiple channels (composite mode or RGB),
         # ensure that the channel axis is also sliced
-        if c_ax := self.normed_channel_axis:
+        if (c_ax := self.normed_channel_axis) is not None:
             if self.display.channel_mode.is_multichannel():
                 if not isinstance(requested_slice.get(c_ax), slice):
                     requested_slice[c_ax] = slice(None)


### PR DESCRIPTION
fixes a silly bug that @fdrgsp encountered when the channel axis is zero (because I checked `if ...` rather than `if ... is not None` 😖) 