### PR TITLE
feat: add `call_later` (public) and `process_events` (private) to the NDVApp API

### DIFF
--- a/src/ndv/views/__init__.py
+++ b/src/ndv/views/__init__.py
@@ -7,6 +7,7 @@ shows the protocol that GUI & graphics classes should implement.
 from ._app import (
     CanvasBackend,
     GuiFrontend,
+    call_later,
     get_array_canvas_class,
     get_array_view_class,
     get_histogram_canvas_class,
@@ -17,6 +18,7 @@ from ._app import (
 __all__ = [
     "CanvasBackend",
     "GuiFrontend",
+    "call_later",
     "get_array_canvas_class",
     "get_array_view_class",
     "get_histogram_canvas_class",

--- a/src/ndv/views/_app.py
+++ b/src/ndv/views/_app.py
@@ -293,6 +293,23 @@ def filter_mouse_events(canvas: Any, receiver: Mouseable) -> Callable[[], None]:
     return ndv_app().filter_mouse_events(canvas, receiver)
 
 
+def call_later(msec: int, func: Callable[[], None]) -> None:
+    """Call `func` after `msec` milliseconds.
+
+    This can be used to enqueue a function to be called after the current event loop
+    iteration.  For example, before calling `run_app()`, to ensure that the event
+    loop is running before the function is called.
+
+    Parameters
+    ----------
+    msec : int
+        The number of milliseconds to wait before calling `func`.
+    func : Callable[[], None]
+        The function to call.
+    """
+    ndv_app().call_later(msec, func)
+
+
 def run_app() -> None:
     """Start the active GUI application event loop."""
     ndv_app().run()

--- a/src/ndv/views/_qt/_app.py
+++ b/src/ndv/views/_qt/_app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
-from qtpy.QtCore import QEvent, QObject
+from qtpy.QtCore import QEvent, QObject, Qt, QTimer
 from qtpy.QtGui import QMouseEvent
 from qtpy.QtWidgets import QApplication
 
@@ -73,6 +73,14 @@ class QtAppWrap(NDVApp):
         f = MouseEventFilter(canvas, receiver)
         canvas.installEventFilter(f)
         return lambda: canvas.removeEventFilter(f)
+
+    def process_events(self) -> None:
+        """Process events for the application."""
+        QApplication.processEvents()
+
+    def call_later(self, msec: int, func: Callable[[], None]) -> None:
+        """Call `func` after `msec` milliseconds."""
+        QTimer.singleShot(msec, Qt.TimerType.PreciseTimer, func)
 
 
 class MouseEventFilter(QObject):

--- a/src/ndv/views/_wx/_app.py
+++ b/src/ndv/views/_wx/_app.py
@@ -89,3 +89,7 @@ class WxAppWrap(NDVApp):
             canvas.Unbind(EVT_LEFT_UP, on_mouse_release)
 
         return _unbind
+
+    def call_later(self, msec: int, func: Callable[[], None]) -> None:
+        """Call `func` after `msec` milliseconds."""
+        wx.CallLater(msec, func)

--- a/src/ndv/views/_wx/_app.py
+++ b/src/ndv/views/_wx/_app.py
@@ -90,6 +90,10 @@ class WxAppWrap(NDVApp):
 
         return _unbind
 
+    def process_events(self) -> None:
+        """Process events."""
+        wx.SafeYield()
+
     def call_later(self, msec: int, func: Callable[[], None]) -> None:
         """Call `func` after `msec` milliseconds."""
         wx.CallLater(msec, func)

--- a/src/ndv/views/bases/_app.py
+++ b/src/ndv/views/bases/_app.py
@@ -89,6 +89,18 @@ class NDVApp:
         sys._original_excepthook_ = sys.excepthook  # type: ignore
         sys.excepthook = ndv_excepthook
 
+    def process_events(self) -> None:
+        """Process events for the application."""
+        pass
+
+    def call_later(self, msec: int, func: Callable[[], None]) -> None:
+        """Call `func` after `msec` milliseconds."""
+        # generic implementation using python threading
+
+        from threading import Timer
+
+        Timer(msec / 1000, func).start()
+
 
 @cache
 def _thread_pool_executor() -> ThreadPoolExecutor:


### PR DESCRIPTION
Something we generally need to be able to do in all gui frontends is call the equivalent of Qt's `QTimer.singleShot()` or `QApplication.processEvents()`.  this adds those two things to the App protocol, and exposes `ndv.call_later` (which is convenient for examples, and such)