### PR TITLE
feat: add widget visibility options to ArrayViewerModel

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -475,7 +475,7 @@ class ArrayViewer:
             future.add_done_callback(self._on_data_response_ready)
 
         if self._futures:
-            self._view.set_progress_spinner_visible(True)
+            self._viewer_model.show_progress_spinner = True
 
     def _is_idle(self) -> bool:
         """Return True if no futures are running. Used for testing, and debugging."""
@@ -490,7 +490,7 @@ class ArrayViewer:
         while self._futures:
             self._futures.pop().cancel()
         self._futures.clear()
-        self._view.set_progress_spinner_visible(False)
+        self._viewer_model.show_progress_spinner = False
 
     @_app.ensure_main_thread
     def _on_data_response_ready(self, future: Future[DataResponse]) -> None:
@@ -499,7 +499,7 @@ class ArrayViewer:
         # which will prevent the widget from being garbage collected if the future
         self._futures.discard(future)
         if not self._futures:
-            self._view.set_progress_spinner_visible(False)
+            self._viewer_model.show_progress_spinner = False
 
         if future.cancelled():
             return

--- a/src/ndv/models/_viewer_model.py
+++ b/src/ndv/models/_viewer_model.py
@@ -1,6 +1,10 @@
 from enum import Enum, auto
+from typing import TYPE_CHECKING
 
 from ndv.models._base_model import NDVModel
+
+if TYPE_CHECKING:
+    from psygnal import Signal, SignalGroup
 
 
 class InteractionMode(Enum):
@@ -22,6 +26,36 @@ class ArrayViewerModel(NDVModel):
     ----------
     interaction_mode : InteractionMode
         Describes the current interaction mode of the Viewer.
+    show_3d_button : bool, optional
+        Whether to show the 3D button, by default True.
+    show_histogram_button : bool, optional
+        Whether to show the histogram button, by default True.
+    show_reset_zoom_button : bool, optional
+        Whether to show the reset zoom button, by default True.
+    show_roi_button : bool, optional
+        Whether to show the ROI button, by default True.
+    show_channel_mode_selector : bool, optional
+        Whether to show the channel mode selector, by default True.
     """
 
     interaction_mode: InteractionMode = InteractionMode.PAN_ZOOM
+    show_3d_button: bool = True
+    show_histogram_button: bool = True
+    show_reset_zoom_button: bool = True
+    show_roi_button: bool = True
+    show_channel_mode_selector: bool = True
+
+    if TYPE_CHECKING:
+        # just to make IDE autocomplete better
+        # it's still hard to indicate dynamic members in the events group
+        class ArrayViewerModelEvents(SignalGroup):
+            """Signal group for ArrayViewerModel."""
+
+            interaction_mode = Signal(InteractionMode, InteractionMode)
+            show_3d_button = Signal(bool, bool)
+            show_histogram_button = Signal(bool, bool)
+            show_reset_zoom_button = Signal(bool, bool)
+            show_roi_button = Signal(bool, bool)
+            show_channel_mode_selector = Signal(bool, bool)
+
+        events: ArrayViewerModelEvents  # type: ignore

--- a/src/ndv/models/_viewer_model.py
+++ b/src/ndv/models/_viewer_model.py
@@ -36,6 +36,8 @@ class ArrayViewerModel(NDVModel):
         Whether to show the ROI button, by default True.
     show_channel_mode_selector : bool, optional
         Whether to show the channel mode selector, by default True.
+    show_progress_spinner : bool, optional
+        Whether to show the progress spinner, by default
     """
 
     interaction_mode: InteractionMode = InteractionMode.PAN_ZOOM
@@ -44,6 +46,7 @@ class ArrayViewerModel(NDVModel):
     show_reset_zoom_button: bool = True
     show_roi_button: bool = True
     show_channel_mode_selector: bool = True
+    show_progress_spinner: bool = False
 
     if TYPE_CHECKING:
         # just to make IDE autocomplete better
@@ -57,5 +60,6 @@ class ArrayViewerModel(NDVModel):
             show_reset_zoom_button = Signal(bool, bool)
             show_roi_button = Signal(bool, bool)
             show_channel_mode_selector = Signal(bool, bool)
+            show_progress_spinner = Signal(bool, bool)
 
-        events: ArrayViewerModelEvents  # type: ignore
+        events: ArrayViewerModelEvents = ArrayViewerModelEvents()  # type: ignore

--- a/src/ndv/views/_jupyter/_array_view.py
+++ b/src/ndv/views/_jupyter/_array_view.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from ndv._types import AxisKey
     from ndv.models._data_display_model import _ArrayDataDisplayModel
+    from ndv.views.bases._array_view import ArrayViewOptions
 
 # not entirely sure why it's necessary to specifically annotat signals as : PSignal
 # i think it has to do with type variance?
@@ -411,3 +412,15 @@ class JupyterArrayView(ArrayView):
 
     def set_progress_spinner_visible(self, visible: bool) -> None:
         self._progress_spinner.layout.display = "flex" if visible else "none"
+
+    def set_options(self, options: ArrayViewOptions) -> None:
+        if (show_3d := options.show_3d_button) is not None:
+            self._ndims_btn.layout.display = "flex" if show_3d else "none"
+        # if (show_hist := options.show_histogram_button) is not None:
+        # self._hist_btn.layout.display = "flex" if show_hist else "none"
+        if (show_reset := options.show_reset_zoom_button) is not None:
+            self._reset_zoom_btn.layout.display = "flex" if show_reset else "none"
+        if (show_channel := options.show_channel_mode_selector) is not None:
+            self._channel_mode_combo.layout.display = "flex" if show_channel else "none"
+        if (show_roi := options.show_roi_button) is not None:
+            self._add_roi_btn.layout.display = "flex" if show_roi else "none"

--- a/src/ndv/views/_jupyter/_array_view.py
+++ b/src/ndv/views/_jupyter/_array_view.py
@@ -403,13 +403,12 @@ class JupyterArrayView(ArrayView):
     def close(self) -> None:
         self.layout.close()
 
-    def set_progress_spinner_visible(self, visible: bool) -> None:
-        self._progress_spinner.layout.display = "flex" if visible else "none"
-
     def _on_viewer_model_event(self, info: EmissionInfo) -> None:
         sig_name = info.signal.name
         value = info.args[0]
-        if sig_name == "interaction_mode":
+        if sig_name == "show_progress_spinner":
+            self._progress_spinner.layout.display = "flex" if value else "none"
+        elif sig_name == "interaction_mode":
             # If leaving CanvasMode.CREATE_ROI, uncheck the ROI button
             new, old = info.args
             if old == InteractionMode.CREATE_ROI:

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
     from ndv._types import AxisKey
     from ndv.models._data_display_model import _ArrayDataDisplayModel
+    from ndv.views.bases._array_view import ArrayViewOptions
     from ndv.views.bases._graphics._canvas_elements import (
         CanvasElement,
         RectangularROIHandle,
@@ -572,3 +573,15 @@ class QtArrayView(ArrayView):
         self._viewer_model.interaction_mode = (
             InteractionMode.CREATE_ROI if checked else InteractionMode.PAN_ZOOM
         )
+
+    def set_options(self, options: ArrayViewOptions) -> None:
+        if (show_3d := options.show_3d_button) is not None:
+            self._qwidget.ndims_btn.setVisible(show_3d)
+        if (show_hist := options.show_histogram_button) is not None:
+            self._qwidget.histogram_btn.setVisible(show_hist)
+        if (show_reset := options.show_reset_zoom_button) is not None:
+            self._qwidget.set_range_btn.setVisible(show_reset)
+        if (show_channel := options.show_channel_mode_selector) is not None:
+            self._qwidget.channel_mode_combo.setVisible(show_channel)
+        if (show_roi := options.show_roi_button) is not None:
+            self._qwidget.add_roi_btn.setVisible(show_roi)

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -560,9 +560,6 @@ class QtArrayView(ArrayView):
     def frontend_widget(self) -> QWidget:
         return self._qwidget
 
-    def set_progress_spinner_visible(self, visible: bool) -> None:
-        self._qwidget._progress_spinner.setVisible(visible)
-
     def _on_add_roi_clicked(self, checked: bool) -> None:
         self._viewer_model.interaction_mode = (
             InteractionMode.CREATE_ROI if checked else InteractionMode.PAN_ZOOM
@@ -571,6 +568,8 @@ class QtArrayView(ArrayView):
     def _on_viewer_model_event(self, info: EmissionInfo) -> None:
         sig_name = info.signal.name
         value = info.args[0]
+        if sig_name == "show_progress_spinner":
+            self._qwidget._progress_spinner.setVisible(value)
         if sig_name == "interaction_mode":
             # If leaving CanvasMode.CREATE_ROI, uncheck the ROI button
             new, old = info.args

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -400,7 +400,7 @@ class WxArrayView(ArrayView):
         sig_name = info.signal.name
         value = info.args[0]
         if sig_name == "show_progress_spinner":
-            _set_visible(self._wxwidget._progress_spinner, value)
+            self._wxwidget._progress_spinner.Show(value)
             self._wxwidget._top_info.Layout()
         elif sig_name == "interaction_mode":
             # If leaving CanvasMode.CREATE_ROI, uncheck the ROI button
@@ -411,21 +411,14 @@ class WxArrayView(ArrayView):
             # _set_visible(self._wxwidget.histogram_btn, value)
             ...
         elif sig_name == "show_roi_button":
-            _set_visible(self._wxwidget.add_roi_btn, value)
+            self._wxwidget.add_roi_btn.Show(value)
             self._wxwidget._btns.Layout()
         elif sig_name == "show_channel_mode_selector":
-            _set_visible(self._wxwidget.channel_mode_combo, value)
+            self._wxwidget.channel_mode_combo.Show(value)
             self._wxwidget._btns.Layout()
         elif sig_name == "show_reset_zoom_button":
-            _set_visible(self._wxwidget.set_range_btn, value)
+            self._wxwidget.set_range_btn.Show(value)
             self._wxwidget._btns.Layout()
         elif sig_name == "show_3d_button":
-            _set_visible(self._wxwidget.ndims_btn, value)
+            self._wxwidget.ndims_btn.Show(value)
             self._wxwidget._btns.Layout()
-
-
-def _set_visible(widget: wx.Window, visible: bool) -> None:
-    if visible:
-        widget.Show()
-    else:
-        widget.Hide()

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from ndv._types import AxisKey
     from ndv.models._data_display_model import _ArrayDataDisplayModel
+    from ndv.views.bases._array_view import ArrayViewOptions
 
 
 class _WxSpinner(wx.Panel):
@@ -403,3 +404,17 @@ class WxArrayView(ArrayView):
             self._wxwidget._top_info.Layout()
         else:
             self._wxwidget._progress_spinner.Hide()
+
+    def set_options(self, options: ArrayViewOptions) -> None:
+        if (show_3d := options.show_3d_button) is not None:
+            getattr(self._wxwidget.ndims_btn, "Show" if show_3d else "Hide")()
+        # if (show_hist := options.show_histogram_button) is not None:
+        # self._wxwidget.histogram_btn.setVisible(show_hist)
+        if (show_reset := options.show_reset_zoom_button) is not None:
+            getattr(self._wxwidget.reset_zoom_btn, "Show" if show_reset else "Hide")()
+        if (show_channel := options.show_channel_mode_selector) is not None:
+            getattr(
+                self._wxwidget.channel_mode_combo, "Show" if show_channel else "Hide"
+            )()
+        if (show_roi := options.show_roi_button) is not None:
+            getattr(self._wxwidget.add_roi_btn, "Show" if show_roi else "Hide")()

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -74,7 +74,3 @@ class ArrayView(Viewable):
 
     def remove_histogram(self, widget: Any) -> None:
         raise NotImplementedError
-
-    # could be moved to set_options?
-    def set_progress_spinner_visible(self, visible: bool) -> None:
-        return

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from psygnal import Signal
@@ -17,6 +18,17 @@ if TYPE_CHECKING:
     from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.models._viewer_model import ArrayViewerModel
     from ndv.views.bases import LutView
+
+
+@dataclass
+class ArrayViewOptions:
+    """Options for configuring an ArrayView widget."""
+
+    show_3d_button: bool | None = None
+    show_histogram_button: bool | None = None
+    show_reset_zoom_button: bool | None = None
+    show_roi_button: bool | None = None
+    show_channel_mode_selector: bool | None = None
 
 
 class ArrayView(Viewable):
@@ -75,5 +87,10 @@ class ArrayView(Viewable):
     def remove_histogram(self, widget: Any) -> None:
         raise NotImplementedError
 
+    # could be moved to set_options?
     def set_progress_spinner_visible(self, visible: bool) -> None:
         return
+
+    def set_options(self, options: ArrayViewOptions) -> None:
+        """Configure the viewer with the given options."""
+        pass

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from psygnal import Signal
@@ -18,17 +17,6 @@ if TYPE_CHECKING:
     from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.models._viewer_model import ArrayViewerModel
     from ndv.views.bases import LutView
-
-
-@dataclass
-class ArrayViewOptions:
-    """Options for configuring an ArrayView widget."""
-
-    show_3d_button: bool | None = None
-    show_histogram_button: bool | None = None
-    show_reset_zoom_button: bool | None = None
-    show_roi_button: bool | None = None
-    show_channel_mode_selector: bool | None = None
 
 
 class ArrayView(Viewable):
@@ -90,7 +78,3 @@ class ArrayView(Viewable):
     # could be moved to set_options?
     def set_progress_spinner_visible(self, visible: bool) -> None:
         return
-
-    def set_options(self, options: ArrayViewOptions) -> None:
-        """Configure the viewer with the given options."""
-        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def asyncio_app() -> Iterator[AbstractEventLoop]:
     loop.close()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def wxapp() -> Iterator[wx.App]:
     import wx
 

--- a/tests/views/_jupyter/test_array_view.py
+++ b/tests/views/_jupyter/test_array_view.py
@@ -6,7 +6,6 @@ from pytest import fixture
 from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._jupyter._array_view import JupyterArrayView
-from ndv.views.bases._array_view import ArrayViewOptions
 
 
 @fixture
@@ -18,20 +17,17 @@ def viewer() -> JupyterArrayView:
 
 def test_array_options(viewer: JupyterArrayView) -> None:
     assert viewer._ndims_btn.layout.display is None
-    assert viewer._reset_zoom_btn.layout.display is None
-    assert viewer._channel_mode_combo.layout.display is None
-    assert viewer._add_roi_btn.layout.display is None
-
-    options = ArrayViewOptions(
-        show_3d_button=False,
-        show_channel_mode_selector=False,
-        show_histogram_button=False,
-        show_reset_zoom_button=False,
-        show_roi_button=False,
-    )
-    viewer.set_options(options)
-
+    viewer._viewer_model.show_3d_button = False
     assert viewer._ndims_btn.layout.display == "none"
+
+    assert viewer._reset_zoom_btn.layout.display is None
+    viewer._viewer_model.show_reset_zoom_button = False
     assert viewer._reset_zoom_btn.layout.display == "none"
+
+    assert viewer._channel_mode_combo.layout.display is None
+    viewer._viewer_model.show_channel_mode_selector = False
     assert viewer._channel_mode_combo.layout.display == "none"
+
+    assert viewer._add_roi_btn.layout.display is None
+    viewer._viewer_model.show_roi_button = False
     assert viewer._add_roi_btn.layout.display == "none"

--- a/tests/views/_jupyter/test_array_view.py
+++ b/tests/views/_jupyter/test_array_view.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ipywidgets
+from pytest import fixture
+
+from ndv.models._data_display_model import _ArrayDataDisplayModel
+from ndv.models._viewer_model import ArrayViewerModel
+from ndv.views._jupyter._array_view import JupyterArrayView
+from ndv.views.bases._array_view import ArrayViewOptions
+
+
+@fixture
+def viewer() -> JupyterArrayView:
+    return JupyterArrayView(
+        ipywidgets.DOMWidget(), _ArrayDataDisplayModel(), ArrayViewerModel()
+    )
+
+
+def test_array_options(viewer: JupyterArrayView) -> None:
+    assert viewer._ndims_btn.layout.display is None
+    assert viewer._reset_zoom_btn.layout.display is None
+    assert viewer._channel_mode_combo.layout.display is None
+    assert viewer._add_roi_btn.layout.display is None
+
+    options = ArrayViewOptions(
+        show_3d_button=False,
+        show_channel_mode_selector=False,
+        show_histogram_button=False,
+        show_reset_zoom_button=False,
+        show_roi_button=False,
+    )
+    viewer.set_options(options)
+
+    assert viewer._ndims_btn.layout.display == "none"
+    assert viewer._reset_zoom_btn.layout.display == "none"
+    assert viewer._channel_mode_combo.layout.display == "none"
+    assert viewer._add_roi_btn.layout.display == "none"

--- a/tests/views/_qt/conftest.py
+++ b/tests/views/_qt/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pytest import fixture
+
+from ndv.views._qt._app import QtAppWrap
+
+
+@fixture(autouse=True)
+def init_provider() -> None:
+    provider = QtAppWrap()
+    provider.create_app()

--- a/tests/views/_qt/test_array_view.py
+++ b/tests/views/_qt/test_array_view.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest import fixture
+from qtpy.QtWidgets import QWidget
+
+from ndv.models._data_display_model import _ArrayDataDisplayModel
+from ndv.models._viewer_model import ArrayViewerModel
+from ndv.views._qt._array_view import QtArrayView
+from ndv.views.bases._array_view import ArrayViewOptions
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+
+@fixture
+def viewer(qtbot: QtBot) -> QtArrayView:
+    viewer = QtArrayView(QWidget(), _ArrayDataDisplayModel(), ArrayViewerModel())
+    qtbot.addWidget(viewer.frontend_widget())
+    return viewer
+
+
+def test_array_options(viewer: QtArrayView) -> None:
+    qwdg = viewer._qwidget
+    qwdg.show()
+    assert qwdg.ndims_btn.isVisible()
+    assert qwdg.histogram_btn.isVisible()
+    assert qwdg.set_range_btn.isVisible()
+    assert qwdg.channel_mode_combo.isVisible()
+    assert qwdg.add_roi_btn.isVisible()
+
+    options = ArrayViewOptions(
+        show_3d_button=False,
+        show_channel_mode_selector=False,
+        show_histogram_button=False,
+        show_reset_zoom_button=False,
+        show_roi_button=False,
+    )
+    viewer.set_options(options)
+
+    assert not qwdg.ndims_btn.isVisible()
+    assert not qwdg.histogram_btn.isVisible()
+    assert not qwdg.set_range_btn.isVisible()
+    assert not qwdg.channel_mode_combo.isVisible()
+    assert not qwdg.add_roi_btn.isVisible()

--- a/tests/views/_qt/test_array_view.py
+++ b/tests/views/_qt/test_array_view.py
@@ -8,7 +8,6 @@ from qtpy.QtWidgets import QWidget
 from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._qt._array_view import QtArrayView
-from ndv.views.bases._array_view import ArrayViewOptions
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -25,22 +24,21 @@ def test_array_options(viewer: QtArrayView) -> None:
     qwdg = viewer._qwidget
     qwdg.show()
     assert qwdg.ndims_btn.isVisible()
-    assert qwdg.histogram_btn.isVisible()
-    assert qwdg.set_range_btn.isVisible()
-    assert qwdg.channel_mode_combo.isVisible()
-    assert qwdg.add_roi_btn.isVisible()
-
-    options = ArrayViewOptions(
-        show_3d_button=False,
-        show_channel_mode_selector=False,
-        show_histogram_button=False,
-        show_reset_zoom_button=False,
-        show_roi_button=False,
-    )
-    viewer.set_options(options)
-
+    viewer._viewer_model.show_3d_button = False
     assert not qwdg.ndims_btn.isVisible()
+
+    assert qwdg.histogram_btn.isVisible()
+    viewer._viewer_model.show_histogram_button = False
     assert not qwdg.histogram_btn.isVisible()
+
+    assert qwdg.set_range_btn.isVisible()
+    viewer._viewer_model.show_reset_zoom_button = False
     assert not qwdg.set_range_btn.isVisible()
+
+    assert qwdg.channel_mode_combo.isVisible()
+    viewer._viewer_model.show_channel_mode_selector = False
     assert not qwdg.channel_mode_combo.isVisible()
+
+    assert qwdg.add_roi_btn.isVisible()
+    viewer._viewer_model.show_roi_button = False
     assert not qwdg.add_roi_btn.isVisible()

--- a/tests/views/_qt/test_lut_view.py
+++ b/tests/views/_qt/test_lut_view.py
@@ -6,17 +6,10 @@ import cmap
 from pytest import fixture
 
 from ndv.models._lut_model import ClimsManual, ClimsMinMax, LUTModel
-from ndv.views._qt._app import QtAppWrap
 from ndv.views._qt._array_view import QLutView
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
-
-
-@fixture(autouse=True)
-def init_provider() -> None:
-    provider = QtAppWrap()
-    provider.create_app()
 
 
 @fixture

--- a/tests/views/_wx/test_array_view.py
+++ b/tests/views/_wx/test_array_view.py
@@ -8,7 +8,6 @@ from pytest import fixture
 from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._wx._array_view import WxArrayView
-from ndv.views.bases._array_view import ArrayViewOptions
 
 if TYPE_CHECKING:
     import wx
@@ -22,23 +21,23 @@ def viewer(wxapp: wx.App) -> WxArrayView:
 def test_array_options(viewer: WxArrayView) -> None:
     wxwdg = viewer._wxwidget
     wxwdg.Show()
+
     assert wxwdg.ndims_btn.IsShown()
-    # assert wxwdg.histogram_btn.IsShown()
-    assert wxwdg.reset_zoom_btn.IsShown()
-    assert wxwdg.channel_mode_combo.IsShown()
-    assert wxwdg.add_roi_btn.IsShown()
-
-    options = ArrayViewOptions(
-        show_3d_button=False,
-        show_channel_mode_selector=False,
-        show_histogram_button=False,
-        show_reset_zoom_button=False,
-        show_roi_button=False,
-    )
-    viewer.set_options(options)
-
+    viewer._viewer_model.show_3d_button = False
     assert not wxwdg.ndims_btn.IsShown()
+
+    # assert wxwdg.histogram_btn.IsShown()
+    # viewer._viewer_model.show_histogram_button = False
     # assert not wxwdg.histogram_btn.IsShown()
-    assert not wxwdg.reset_zoom_btn.IsShown()
+
+    assert wxwdg.set_range_btn.IsShown()
+    viewer._viewer_model.show_reset_zoom_button = False
+    assert not wxwdg.set_range_btn.IsShown()
+
+    assert wxwdg.channel_mode_combo.IsShown()
+    viewer._viewer_model.show_channel_mode_selector = False
     assert not wxwdg.channel_mode_combo.IsShown()
+
+    assert wxwdg.add_roi_btn.IsShown()
+    viewer._viewer_model.show_roi_button = False
     assert not wxwdg.add_roi_btn.IsShown()

--- a/tests/views/_wx/test_array_view.py
+++ b/tests/views/_wx/test_array_view.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from pytest import fixture
+
+from ndv.models._data_display_model import _ArrayDataDisplayModel
+from ndv.models._viewer_model import ArrayViewerModel
+from ndv.views._wx._array_view import WxArrayView
+from ndv.views.bases._array_view import ArrayViewOptions
+
+if TYPE_CHECKING:
+    import wx
+
+
+@fixture
+def viewer(wxapp: wx.App) -> WxArrayView:
+    return WxArrayView(MagicMock(), _ArrayDataDisplayModel(), ArrayViewerModel())
+
+
+def test_array_options(viewer: WxArrayView) -> None:
+    wxwdg = viewer._wxwidget
+    wxwdg.Show()
+    assert wxwdg.ndims_btn.IsShown()
+    # assert wxwdg.histogram_btn.IsShown()
+    assert wxwdg.reset_zoom_btn.IsShown()
+    assert wxwdg.channel_mode_combo.IsShown()
+    assert wxwdg.add_roi_btn.IsShown()
+
+    options = ArrayViewOptions(
+        show_3d_button=False,
+        show_channel_mode_selector=False,
+        show_histogram_button=False,
+        show_reset_zoom_button=False,
+        show_roi_button=False,
+    )
+    viewer.set_options(options)
+
+    assert not wxwdg.ndims_btn.IsShown()
+    # assert not wxwdg.histogram_btn.IsShown()
+    assert not wxwdg.reset_zoom_btn.IsShown()
+    assert not wxwdg.channel_mode_combo.IsShown()
+    assert not wxwdg.add_roi_btn.IsShown()

--- a/tests/views/_wx/test_lut_view.py
+++ b/tests/views/_wx/test_lut_view.py
@@ -5,15 +5,7 @@ import wx
 from pytest import fixture
 
 from ndv.models._lut_model import ClimsManual, ClimsMinMax, LUTModel
-from ndv.views._wx._app import WxAppWrap
 from ndv.views._wx._array_view import WxLutView
-
-
-@fixture(autouse=True, scope="module")
-def app() -> wx.App:
-    # Create wx app
-    provider = WxAppWrap()
-    return provider.create_app()
 
 
 @fixture
@@ -22,7 +14,7 @@ def model() -> LUTModel:
 
 
 @fixture
-def view(app: wx.App, model: LUTModel) -> WxLutView:
+def view(wxapp: wx.App, model: LUTModel) -> WxLutView:
     # NB: wx.App necessary although unused
     frame = wx.Frame(None)
     view = WxLutView(frame)
@@ -50,7 +42,7 @@ def test_WxLutView_update_model(model: LUTModel, view: WxLutView) -> None:
     assert view._wxwidget.cmap.GetValue() == new_cmap
 
 
-def test_WxLutView_update_view(app: wx.App, model: LUTModel, view: WxLutView) -> None:
+def test_WxLutView_update_view(wxapp: wx.App, model: LUTModel, view: WxLutView) -> None:
     """Ensures the model updates when the view is changed."""
 
     def processEvent(evt: wx.PyEventBinder, wdg: wx.Control) -> None:
@@ -58,7 +50,7 @@ def test_WxLutView_update_view(app: wx.App, model: LUTModel, view: WxLutView) ->
         wx.PostEvent(wdg.GetEventHandler(), ev)
         # Borrowed from:
         # https://github.com/wxWidgets/Phoenix/blob/master/unittests/wtc.py#L41
-        evtLoop = app.GetTraits().CreateEventLoop()
+        evtLoop = wxapp.GetTraits().CreateEventLoop()
         wx.EventLoopActivator(evtLoop)
         evtLoop.YieldFor(wx.EVT_CATEGORY_ALL)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3134,6 +3134,7 @@ wheels = [
 
 [[package]]
 name = "ndv"
+version = "0.2.3.dev7+g0ea22af"
 source = { editable = "." }
 dependencies = [
     { name = "cmap" },
@@ -4284,6 +4285,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ff/209975c42d05445e884b59ebea44a86b42a7d8ad8b831c930d06bc3a5fc6/psygnal-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69d74edb336e5e959ef5680c5393f8f6c7b7561fdcb9014dc2535c6ef3ea194", size = 770509 },
     { url = "https://files.pythonhosted.org/packages/c0/27/a60b0328267709a30274df55c358cedad596b09cc97f687cd01303d17fa3/psygnal-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7986828b57861b3341803e519e09189cd93800adede9cfc450e72e1c4ea93f35", size = 759198 },
     { url = "https://files.pythonhosted.org/packages/ef/49/cd7ee6a1d4e8fd37e6040f937232c4a32ebd164c2cdea489d7f2493d7ae2/psygnal-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:ef3cae9af7a22f3c855cbc5b2cb219c5410b1076eaa6541f48cdb2c901a06ad7", size = 372115 },
+    { url = "https://files.pythonhosted.org/packages/eb/fa/84fc30ad391081cb119099aae5491ba4a9ebd34ce5139bf05b31813abb84/psygnal-0.12.0-py3-none-any.whl", hash = "sha256:15f39abd8bee2926e79da76bec31a258d03dbe3e61d22d6251f65caefbae5d54", size = 78492 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3134,7 +3134,6 @@ wheels = [
 
 [[package]]
 name = "ndv"
-version = "0.2.3.dev7+g0ea22af"
 source = { editable = "." }
 dependencies = [
     { name = "cmap" },
@@ -4285,7 +4284,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ff/209975c42d05445e884b59ebea44a86b42a7d8ad8b831c930d06bc3a5fc6/psygnal-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69d74edb336e5e959ef5680c5393f8f6c7b7561fdcb9014dc2535c6ef3ea194", size = 770509 },
     { url = "https://files.pythonhosted.org/packages/c0/27/a60b0328267709a30274df55c358cedad596b09cc97f687cd01303d17fa3/psygnal-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7986828b57861b3341803e519e09189cd93800adede9cfc450e72e1c4ea93f35", size = 759198 },
     { url = "https://files.pythonhosted.org/packages/ef/49/cd7ee6a1d4e8fd37e6040f937232c4a32ebd164c2cdea489d7f2493d7ae2/psygnal-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:ef3cae9af7a22f3c855cbc5b2cb219c5410b1076eaa6541f48cdb2c901a06ad7", size = 372115 },
-    { url = "https://files.pythonhosted.org/packages/eb/fa/84fc30ad391081cb119099aae5491ba4a9ebd34ce5139bf05b31813abb84/psygnal-0.12.0-py3-none-any.whl", hash = "sha256:15f39abd8bee2926e79da76bec31a258d03dbe3e61d22d6251f65caefbae5d54", size = 78492 },
 ]
 
 [[package]]


### PR DESCRIPTION
In #134, I want to be able to reuse the ArrayView objects, but hide some of the widgets that aren't relevant in that context (such as the 3D button, and other widgets).  This PR adds various options to `ArrayViewerModel` that control the visibility of various elements:

```
    show_3d_button: bool = True
    show_histogram_button: bool = True
    show_reset_zoom_button: bool = True
    show_roi_button: bool = True
    show_channel_mode_selector: bool = True
    show_progress_spinner: bool = False
```