### PR TITLE
refactor: use rendercanvas instead of wgpu.gui

### DIFF
--- a/src/ndv/data.py
+++ b/src/ndv/data.py
@@ -50,7 +50,7 @@ def nd_sine_wave(
                 # Assign to the output array
                 output[angle_idx, freq_idx, phase_idx] = sine_wave
 
-    return output
+    return output.astype(np.float32)
 
 
 def cells3d() -> np.ndarray:

--- a/src/ndv/views/_pygfx/_array_canvas.py
+++ b/src/ndv/views/_pygfx/_array_canvas.py
@@ -22,6 +22,8 @@ from ndv.views._app import filter_mouse_events
 from ndv.views.bases import ArrayCanvas, CanvasElement, ImageHandle
 from ndv.views.bases._graphics._canvas_elements import RectangularROIHandle, ROIMoveMode
 
+from ._util import rendercanvas_class
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import TypeAlias
@@ -347,32 +349,6 @@ class PyGFXRectangle(RectangularROIHandle):
             par.remove(self._container)
 
 
-def get_canvas_class() -> WgpuCanvas:
-    from ndv.views._app import GuiFrontend, gui_frontend
-
-    frontend = gui_frontend()
-    if frontend == GuiFrontend.QT:
-        from qtpy.QtCore import QSize
-        from wgpu.gui import qt
-
-        class QWgpuCanvas(qt.QWgpuCanvas):
-            def installEventFilter(self, filter: Any) -> None:
-                self._subwidget.installEventFilter(filter)
-
-            def sizeHint(self) -> QSize:
-                return QSize(self.width(), self.height())
-
-        return QWgpuCanvas
-    if frontend == GuiFrontend.JUPYTER:
-        from wgpu.gui.jupyter import JupyterWgpuCanvas
-
-        return JupyterWgpuCanvas
-    if frontend == GuiFrontend.WX:
-        from wgpu.gui.wx import WxWgpuCanvas
-
-        return WxWgpuCanvas
-
-
 class GfxArrayCanvas(ArrayCanvas):
     """pygfx-based canvas wrapper."""
 
@@ -382,14 +358,14 @@ class GfxArrayCanvas(ArrayCanvas):
         self._current_shape: tuple[int, ...] = ()
         self._last_state: dict[Literal[2, 3], Any] = {}
 
-        cls = get_canvas_class()
+        cls = rendercanvas_class()
         self._canvas = cls(size=(600, 600))
+
         # this filter needs to remain in scope for the lifetime of the canvas
         # or mouse events will not be intercepted
         # the returned function can be called to remove the filter, (and it also
         # closes on the event filter and keeps it in scope).
         self._disconnect_mouse_events = filter_mouse_events(self._canvas, self)
-
         self._renderer = pygfx.renderers.WgpuRenderer(self._canvas)
         try:
             # requires https://github.com/pygfx/pygfx/pull/752

--- a/src/ndv/views/_pygfx/_histogram.py
+++ b/src/ndv/views/_pygfx/_histogram.py
@@ -14,6 +14,8 @@ from ndv.models._lut_model import ClimPolicy, ClimsManual
 from ndv.views._app import filter_mouse_events
 from ndv.views.bases import HistogramCanvas
 
+from ._util import rendercanvas_class
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import TypeAlias
@@ -31,34 +33,6 @@ class Grabbable(Enum):
     LEFT_CLIM = auto()
     RIGHT_CLIM = auto()
     GAMMA = auto()
-
-
-def get_canvas_class() -> WgpuCanvas:
-    from ndv.views._app import GuiFrontend, gui_frontend
-
-    frontend = gui_frontend()
-    if frontend == GuiFrontend.QT:
-        from qtpy.QtCore import QSize
-        from wgpu.gui import qt
-
-        class QWgpuCanvas(qt.QWgpuCanvas):
-            def installEventFilter(self, filter: Any) -> None:
-                self._subwidget.installEventFilter(filter)
-
-            def sizeHint(self) -> QSize:
-                return QSize(self.width(), self.height())
-
-        return QWgpuCanvas
-    if frontend == GuiFrontend.JUPYTER:
-        from wgpu.gui.jupyter import JupyterWgpuCanvas
-
-        return JupyterWgpuCanvas
-    if frontend == GuiFrontend.WX:
-        from wgpu.gui.wx import WxWgpuCanvas
-
-        return WxWgpuCanvas
-
-    raise Exception(f"No canvas available for frontend {frontend}")
 
 
 class PyGFXHistogramCanvas(HistogramCanvas):
@@ -90,7 +64,7 @@ class PyGFXHistogramCanvas(HistogramCanvas):
         self.margin_top = 15
 
         # ------------ PyGFX Canvas ------------ #
-        cls = get_canvas_class()
+        cls = rendercanvas_class()
         self._size = (600, 600)
         self._canvas = cls(size=self._size)
 

--- a/src/ndv/views/_pygfx/_util.py
+++ b/src/ndv/views/_pygfx/_util.py
@@ -1,0 +1,28 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rendercanvas import BaseRenderCanvas
+
+
+def rendercanvas_class() -> "BaseRenderCanvas":
+    from ndv.views._app import GuiFrontend, gui_frontend
+
+    frontend = gui_frontend()
+    if frontend == GuiFrontend.QT:
+        import rendercanvas.qt
+        from qtpy.QtCore import QSize
+
+        class QRenderWidget(rendercanvas.qt.QRenderWidget):
+            def sizeHint(self) -> QSize:
+                return QSize(self.width(), self.height())
+
+        return QRenderWidget
+
+    if frontend == GuiFrontend.JUPYTER:
+        import rendercanvas.jupyter
+
+        return rendercanvas.jupyter.JupyterRenderCanvas
+    if frontend == GuiFrontend.WX:
+        import rendercanvas.wx
+
+        return rendercanvas.wx.WxRenderWidget

--- a/src/ndv/views/_pygfx/_util.py
+++ b/src/ndv/views/_pygfx/_util.py
@@ -23,6 +23,9 @@ def rendercanvas_class() -> "BaseRenderCanvas":
 
         return rendercanvas.jupyter.JupyterRenderCanvas
     if frontend == GuiFrontend.WX:
-        import rendercanvas.wx
+        # ...still not working
+        # import rendercanvas.wx
+        # return rendercanvas.wx.WxRenderWidget
+        from wgpu.gui.wx import WxWgpuCanvas
 
-        return rendercanvas.wx.WxRenderWidget
+        return WxWgpuCanvas

--- a/src/ndv/views/_wx/_app.py
+++ b/src/ndv/views/_wx/_app.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from ndv.views.bases._app import P, T
     from ndv.views.bases._graphics._mouseable import Mouseable
 
+_app = None
+
 
 class WxAppWrap(NDVApp):
     """Provider for wxPython."""
@@ -24,8 +26,9 @@ class WxAppWrap(NDVApp):
     IPY_MAGIC_KEY = "wx"
 
     def create_app(self) -> Any:
+        global _app
         if (wxapp := wx.App.Get()) is None:
-            wxapp = wx.App()
+            _app = wxapp = wx.App()
 
         self._maybe_enable_ipython_gui()
         self._install_excepthook()

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -223,7 +223,6 @@ class _WxArrayViewer(wx.Frame):
 
         # FIXME: pygfx backend needs this to be canvas_widget._subwidget
         if hasattr(canvas_widget, "_subwidget"):
-            breakpoint()
             canvas_widget = canvas_widget._subwidget
 
         if (parent := canvas_widget.GetParent()) and parent is not self:

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -223,6 +223,7 @@ class _WxArrayViewer(wx.Frame):
 
         # FIXME: pygfx backend needs this to be canvas_widget._subwidget
         if hasattr(canvas_widget, "_subwidget"):
+            breakpoint()
             canvas_widget = canvas_widget._subwidget
 
         if (parent := canvas_widget.GetParent()) and parent is not self:


### PR DESCRIPTION
pygfx is moving to using rendercanvas.  This does it too.

there's still something weird going on with wx (segfaults, and issues with timers).  need to troubleshoot that