### PR TITLE
feat: Add autoscale tail ignore via popup

### DIFF
--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -93,29 +93,6 @@ QRangeSlider { qproperty-barColor: qlineargradient(
 """
 
 
-class QtPopup(QDialog):
-    """A generic popup window."""
-
-    def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
-        self.setModal(False)  # if False, then clicking anywhere else closes it
-        self.setWindowFlags(Qt.WindowType.Popup | Qt.WindowType.FramelessWindowHint)
-
-        self.frame = QFrame(self)
-        layout = QVBoxLayout(self)
-        layout.addWidget(self.frame)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-    def show_above_mouse(self, *args: Any) -> None:
-        """Show popup dialog above the mouse cursor position."""
-        pos = QCursor().pos()  # mouse position
-        szhint = self.sizeHint()
-        pos -= QPoint(szhint.width() // 2, szhint.height() + 14)
-        self.move(pos)
-        self.resize(self.sizeHint())
-        self.show()
-
-
 class _CmapCombo(QColormapComboBox):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent, allow_user_colormaps=True, add_colormap_text="Add...")
@@ -161,6 +138,29 @@ class _QSpinner(QLabel):
         effect = QGraphicsOpacityEffect(self)
         effect.setOpacity(0.6)
         self.setGraphicsEffect(effect)
+
+
+class QtPopup(QDialog):
+    """A generic popup window."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setModal(False)  # if False, then clicking anywhere else closes it
+        self.setWindowFlags(Qt.WindowType.Popup | Qt.WindowType.FramelessWindowHint)
+
+        self.frame = QFrame(self)
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+    def show_above_mouse(self, *args: Any) -> None:
+        """Show popup dialog above the mouse cursor position."""
+        pos = QCursor().pos()  # mouse position
+        szhint = self.sizeHint()
+        pos -= QPoint(szhint.width() // 2, szhint.height() + 14)
+        self.move(pos)
+        self.resize(self.sizeHint())
+        self.show()
 
 
 class PlayButton(QPushButton):

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -260,8 +260,8 @@ class _QLUTWidget(QWidget):
         self.auto_popup = QtPopup(self)
         form = QFormLayout(self.auto_popup.frame)
         form.setContentsMargins(6, 6, 6, 6)
-        form.addRow("Ignore Lower Tail:", self.lower_tail)
-        form.addRow("Ignore Upper Tail:", self.upper_tail)
+        form.addRow("Exclude Darkest:", self.lower_tail)
+        form.addRow("Exclude Brightest:", self.upper_tail)
 
         # -- LAYOUT -- #
 

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -307,6 +307,9 @@ class QLutView(LutView):
 
     def set_clim_policy(self, policy: ClimPolicy) -> None:
         self._qwidget.auto_clim.setChecked(not policy.is_manual)
+        if isinstance(policy, ClimsPercentile):
+            self._qwidget.auto_clim.lower_box.setValue(policy.min_percentile)
+            self._qwidget.auto_clim.upper_box.setValue(100 - policy.max_percentile)
 
     def set_colormap(self, cmap: cmap.Colormap) -> None:
         self._qwidget.cmap.setCurrentColormap(cmap)

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -6,20 +6,23 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import psygnal
-from qtpy.QtCore import QSize, Qt, Signal
+from qtpy.QtCore import QPoint, QSize, Qt, Signal
 from qtpy.QtGui import QMovie
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFormLayout,
     QFrame,
     QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QPushButton,
     QSplitter,
     QVBoxLayout,
     QWidget,
+    QWidgetAction,
 )
 from superqt import QCollapsible, QElidingLabel, QLabeledRangeSlider, QLabeledSlider
 from superqt.cmap import QColormapComboBox
@@ -28,7 +31,7 @@ from superqt.utils import signals_blocked
 
 from ndv._types import AxisKey
 from ndv.models._array_display_model import ChannelMode
-from ndv.models._lut_model import ClimPolicy, ClimsManual, ClimsMinMax
+from ndv.models._lut_model import ClimPolicy, ClimsManual, ClimsPercentile
 from ndv.models._viewer_model import ArrayViewerModel, InteractionMode
 from ndv.views.bases import ArrayView, LutView
 
@@ -156,8 +159,17 @@ class _QLUTWidget(QWidget):
         self.clims.setRange(0, 2**16)  # TODO: expose
 
         self.auto_clim = QPushButton("Auto")
+        self.auto_clim.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.auto_clim.customContextMenuRequested.connect(self._show_auto_scale_menu)
         self.auto_clim.setMaximumWidth(42)
         self.auto_clim.setCheckable(True)
+
+        # Note - appears only in the auto context menu
+        self.auto_spinbox = QDoubleSpinBox()
+        self.auto_spinbox.setRange(0, 49.9)
+        self.auto_spinbox.setSingleStep(0.1)
+        self.auto_spinbox.setSuffix("%")
+        self.auto_spinbox.setValue(0)
 
         # TODO: Consider other options here
         add_histogram_icon = QIconifyIcon("foundation:graph-bar")
@@ -181,6 +193,20 @@ class _QLUTWidget(QWidget):
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.addLayout(top)
 
+    def _show_auto_scale_menu(self, position: QPoint) -> None:
+        context_menu = QMenu(self)
+
+        # Create a widget action to hold the spinbox
+        spinbox_action = QWidgetAction(context_menu)
+        spinbox_action.setDefaultWidget(self.auto_spinbox)
+
+        # Add actions to the menu
+        context_menu.addAction("Ignore tails:")
+        context_menu.addAction(spinbox_action)
+
+        # Show the context menu
+        context_menu.exec_(self.auto_clim.mapToGlobal(position))
+
 
 class QLutView(LutView):
     # NB: In practice this will be a ChannelKey but Unions not allowed here.
@@ -196,6 +222,7 @@ class QLutView(LutView):
         self._qwidget.cmap.currentColormapChanged.connect(self._on_q_cmap_changed)
         self._qwidget.clims.valueChanged.connect(self._on_q_clims_changed)
         self._qwidget.auto_clim.toggled.connect(self._on_q_auto_changed)
+        self._qwidget.auto_spinbox.valueChanged.connect(self._on_q_auto_tails_changed)
 
     def frontend_widget(self) -> QWidget:
         return self._qwidget
@@ -241,10 +268,16 @@ class QLutView(LutView):
     def _on_q_auto_changed(self, autoscale: bool) -> None:
         if self._model:
             if autoscale:
-                self._model.clims = ClimsMinMax()
+                tail = self._qwidget.auto_spinbox.value()
+                self._model.clims = ClimsPercentile(
+                    min_percentile=tail, max_percentile=100 - tail
+                )
             else:
                 clims = self._qwidget.clims.value()
                 self._model.clims = ClimsManual(min=clims[0], max=clims[1])
+
+    def _on_q_auto_tails_changed(self, value: float) -> None:
+        self._on_q_auto_changed(self._qwidget.auto_clim.isChecked())
 
     def _on_q_histogram_toggled(self, toggled: bool) -> None:
         if hist := self._qwidget._histogram:

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -94,7 +94,6 @@ class _WxLUTWidget(wx.Panel):
         # Seems related to its encapsulation in the popup window i.e. editable
         # when appended to e.g. self.lut_ctrls
         self.lower_tail = wx.SpinCtrlDouble(self.auto_popup)
-        self.lower_tail.SetLabel("Ignore Lower Tail:")
         self.lower_tail.SetRange(0, 100)
         self.lower_tail.SetIncrement(0.1)
         self.upper_tail = wx.SpinCtrlDouble(self.auto_popup)
@@ -127,10 +126,10 @@ class _WxLUTWidget(wx.Panel):
 
         # Autoscale popup
         self.autoscale_ctrls = wx.FlexGridSizer(rows=2, cols=2, hgap=0, vgap=0)
-        lower_label = wx.StaticText(self.auto_popup, label="Ignore Lower Tail:")
+        lower_label = wx.StaticText(self.auto_popup, label="Exclude Darkest %")
         self.autoscale_ctrls.Add(lower_label, 0, wx.ALL, 2)
         self.autoscale_ctrls.Add(self.lower_tail, 0, wx.ALL, 2)
-        upper_label = wx.StaticText(self.auto_popup, label="Ignore Upper Tail:")
+        upper_label = wx.StaticText(self.auto_popup, label="Exclude Brightest %")
         self.autoscale_ctrls.Add(upper_label, 0, wx.ALL, 2)
         self.autoscale_ctrls.Add(self.upper_tail, 0, wx.ALL, 2)
 

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -68,11 +68,6 @@ def _add_icon(btn: wx.AnyButton, icon: str) -> None:
     btn.SetBitmapLabel(bitmap)
 
 
-class _WxPopup(wx.PopupTransientWindow):
-    def __init__(self, parent: wx.Window, flags: int = wx.SIMPLE_BORDER) -> None:
-        super().__init__(parent, flags)
-
-
 # mostly copied from _qt.qt_view._QLUTWidget
 class _WxLUTWidget(wx.Panel):
     def __init__(self, parent: wx.Window) -> None:
@@ -94,12 +89,14 @@ class _WxLUTWidget(wx.Panel):
 
         self.auto_clim = wx.ToggleButton(self, label="Auto", size=(50, -1))
 
-        self.auto_popup = _WxPopup(self)
-        self.lower_tail = wx.SpinCtrlDouble(self.auto_popup, name="Ignore Lower Tail:")
+        self.auto_popup = wx.PopupTransientWindow(self, flags=wx.SIMPLE_BORDER)
+        # FIXME: These TextCtrls do not seem to be editable
+        # May have something to do with encapsulation in the popup window
+        self.lower_tail = wx.SpinCtrlDouble(self.auto_popup)
         self.lower_tail.SetLabel("Ignore Lower Tail:")
         self.lower_tail.SetRange(0, 100)
         self.lower_tail.SetIncrement(0.1)
-        self.upper_tail = wx.SpinCtrlDouble(self.auto_popup, name="Ignore Upper Tail:")
+        self.upper_tail = wx.SpinCtrlDouble(self.auto_popup)
         self.upper_tail.SetRange(0, 100)
         self.upper_tail.SetIncrement(0.1)
 
@@ -199,7 +196,7 @@ class WxLutView(LutView):
         pos = btn.ClientToScreen((0, 0))
         sz = btn.GetSize()
         self._wxwidget.auto_popup.Position(pos, (0, sz[1]))
-        self._wxwidget.auto_popup.Show(True)
+        self._wxwidget.auto_popup.Popup()
 
     def _on_autoscale_tail_changed(self, event: wx.CommandEvent) -> None:
         self._on_autoscale_changed(event)

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -91,7 +91,8 @@ class _WxLUTWidget(wx.Panel):
 
         self.auto_popup = wx.PopupTransientWindow(self, flags=wx.SIMPLE_BORDER)
         # FIXME: These TextCtrls do not seem to be editable
-        # May have something to do with encapsulation in the popup window
+        # Seems related to its encapsulation in the popup window i.e. editable
+        # when appended to e.g. self.lut_ctrls
         self.lower_tail = wx.SpinCtrlDouble(self.auto_popup)
         self.lower_tail.SetLabel("Ignore Lower Tail:")
         self.lower_tail.SetRange(0, 100)

--- a/tests/views/_qt/test_lut_view.py
+++ b/tests/views/_qt/test_lut_view.py
@@ -41,8 +41,8 @@ def test_QLutView_update_model(model: LUTModel, view: QLutView) -> None:
     model.clims = ClimsPercentile(min_percentile=0, max_percentile=100)
     assert view._qwidget.auto_clim.isChecked()
     model.clims = ClimsPercentile(min_percentile=1, max_percentile=99)
-    assert view._qwidget.auto_clim.lower_box.value() == 1
-    assert view._qwidget.auto_clim.upper_box.value() == 1
+    assert view._qwidget.lower_tail.value() == 1
+    assert view._qwidget.upper_tail.value() == 1
 
     # Test modifying model.visible
     assert view._qwidget.visible.isChecked()
@@ -80,9 +80,9 @@ def test_QLutView_update_view(model: LUTModel, view: QLutView) -> None:
     assert model.clims == ClimsPercentile(min_percentile=0, max_percentile=100)
 
     # Test modifying tails changes percentiles
-    view._qwidget.auto_clim.lower_box.setValue(0.1)
+    view._qwidget.lower_tail.setValue(0.1)
     assert model.clims == ClimsPercentile(min_percentile=0.1, max_percentile=100)
-    view._qwidget.auto_clim.upper_box.setValue(0.2)
+    view._qwidget.upper_tail.setValue(0.2)
     assert model.clims == ClimsPercentile(min_percentile=0.1, max_percentile=99.8)
 
     # When gui clims change, autoscale should be disabled

--- a/tests/views/_qt/test_lut_view.py
+++ b/tests/views/_qt/test_lut_view.py
@@ -7,7 +7,7 @@ import cmap
 from pytest import fixture
 from qtpy.QtWidgets import QWidget
 
-from ndv.models._lut_model import ClimsManual, ClimsMinMax, LUTModel
+from ndv.models._lut_model import ClimsManual, ClimsMinMax, ClimsPercentile, LUTModel
 from ndv.views._qt._array_view import QLutView
 from ndv.views.bases._graphics._canvas import HistogramCanvas
 
@@ -34,15 +34,24 @@ def view(model: LUTModel, qtbot: QtBot) -> QLutView:
 def test_QLutView_update_model(model: LUTModel, view: QLutView) -> None:
     """Ensures the view updates when the model is changed."""
 
-    auto_scale = not model.clims.is_manual
-    assert view._qwidget.auto_clim.isChecked() == auto_scale
-    model.clims = ClimsManual(min=0, max=1) if auto_scale else ClimsMinMax()
-    assert view._qwidget.auto_clim.isChecked() != auto_scale
+    # Test modifying model.clims
+    assert view._qwidget.auto_clim.isChecked()
+    model.clims = ClimsManual(min=0, max=1)
+    assert not view._qwidget.auto_clim.isChecked()
+    model.clims = ClimsPercentile(min_percentile=0, max_percentile=100)
+    assert view._qwidget.auto_clim.isChecked()
+    model.clims = ClimsPercentile(min_percentile=1, max_percentile=99)
+    assert view._qwidget.auto_clim.lower_box.value() == 1
+    assert view._qwidget.auto_clim.upper_box.value() == 1
 
-    new_visible = not model.visible
-    model.visible = new_visible
-    assert view._qwidget.visible.isChecked() == new_visible
+    # Test modifying model.visible
+    assert view._qwidget.visible.isChecked()
+    model.visible = False
+    assert not view._qwidget.visible.isChecked()
+    model.visible = True
+    assert view._qwidget.visible.isChecked()
 
+    # Test modifying model.cmap
     new_cmap = cmap.Colormap("red")
     assert view._qwidget.cmap.currentColormap() != new_cmap
     model.cmap = new_cmap
@@ -62,14 +71,19 @@ def test_QLutView_update_view(model: LUTModel, view: QLutView) -> None:
     view._qwidget.cmap.setCurrentIndex(1)
     assert model.cmap == new_cmap
 
+    # Test toggling auto_clim
+    assert model.clims == ClimsPercentile(min_percentile=0, max_percentile=100)
+    view._qwidget.auto_clim.setChecked(False)
     mi, ma = view._qwidget.clims.value()
-    new_clims = (
-        ClimsManual(min=mi, max=ma)
-        if view._qwidget.auto_clim.isChecked()
-        else ClimsMinMax()
-    )
-    view._qwidget.auto_clim.setChecked(not new_clims.is_manual)
-    assert model.clims == new_clims
+    assert model.clims == ClimsManual(min=mi, max=ma)
+    view._qwidget.auto_clim.setChecked(True)
+    assert model.clims == ClimsPercentile(min_percentile=0, max_percentile=100)
+
+    # Test modifying tails changes percentiles
+    view._qwidget.auto_clim.lower_box.setValue(0.1)
+    assert model.clims == ClimsPercentile(min_percentile=0.1, max_percentile=100)
+    view._qwidget.auto_clim.upper_box.setValue(0.2)
+    assert model.clims == ClimsPercentile(min_percentile=0.1, max_percentile=99.8)
 
     # When gui clims change, autoscale should be disabled
     model.clims = ClimsMinMax()


### PR DESCRIPTION
This PR adds GUI functionality for autoscaling using `ClimsPercentile`, where the user can ignore the outlier samples of the dataset being displayed in autoscale:

https://github.com/user-attachments/assets/3c832b83-904c-400e-b4f7-58cde99a412d

I like the placement as a context menu because it means all autoscaling functionality appears within the same area of the canvas and because it normally does not take up any screen space.

Unfortunately, I do not know whether this design is possible with all our frontends, seeing as how I cannot figure out how to write a context menu in ipywidgets.

We might instead have to settle for adding this widget to the layouts added in #146...