### PR TITLE
tests: update superqt to reduce segfaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,41 +108,13 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
-      - name: 🧪 Test (attempt 1)
-        id: test1
-        continue-on-error: true
+      - name: 🧪 Test
         shell: bash
         run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1
 
-      - name: 🧪 Test (attempt 2)
-        if: steps.test1.outcome == 'failure'
-        id: test2
-        continue-on-error: true
-        shell: bash
-        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1 verbose=1
-
-      - name: 🧪 Test (attempt 3)
-        if: steps.test2.outcome == 'failure'
-        shell: bash
-        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1 verbose=1
-
-      - name: 🧪 Test min dependencies (attempt 1)
-        id: min1
-        continue-on-error: true
+      - name: 🧪 Test min dependencies
         shell: bash
         run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1
-
-      - name: 🧪 Test min dependencies (attempt 2)
-        if: steps.min1.outcome == 'failure'
-        id: min2
-        continue-on-error: true
-        shell: bash
-        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1 verbose=1
-
-      - name: 🧪 Test min dependencies (attempt 3)
-        if: steps.min2.outcome == 'failure'
-        shell: bash
-        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1 verbose=1
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,41 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
-      - name: 🧪 Test
+      - name: 🧪 Test (attempt 1)
+        id: test1
+        continue-on-error: true
         shell: bash
         run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1
 
-      - name: 🧪 Test min dependencies
+      - name: 🧪 Test (attempt 2)
+        if: steps.test1.outcome == 'failure'
+        id: test2
+        continue-on-error: true
+        shell: bash
+        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1 verbose=1
+
+      - name: 🧪 Test (attempt 3)
+        if: steps.test2.outcome == 'failure'
+        shell: bash
+        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" cov=1 verbose=1
+
+      - name: 🧪 Test min dependencies (attempt 1)
+        id: min1
+        continue-on-error: true
         shell: bash
         run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1
+
+      - name: 🧪 Test min dependencies (attempt 2)
+        if: steps.min1.outcome == 'failure'
+        id: min2
+        continue-on-error: true
+        shell: bash
+        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1 verbose=1
+
+      - name: 🧪 Test min dependencies (attempt 3)
+        if: steps.min2.outcome == 'failure'
+        shell: bash
+        run: make test extras="${{ matrix.gui }},${{ matrix.canvas }}" min=1 verbose=1
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,15 +91,7 @@ jobs:
         with:
           enable-cache: true
 
-      # https://github.com/pyvista/setup-headless-display-action/pull/26
-      - name: Configure curl to disable revocation checks and add retries
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo --ssl-no-revoke > C:\Users\runneradmin\_curlrc
-          echo '--retry 5' >> C:\Users\runneradmin\_curlrc
-          type C:\Users\runneradmin\_curlrc
-
-      - uses: pyvista/setup-headless-display-action@v3
+      - uses: pyvista/setup-headless-display-action@main
         with:
           qt: ${{ matrix.gui == 'pyside' || matrix.gui == 'pyqt' }}
       - name: Install llvmpipe and lavapipe for offscreen canvas
@@ -139,7 +131,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - uses: pyvista/setup-headless-display-action@v3
+      - uses: pyvista/setup-headless-display-action@main
         with:
           qt: true
       - name: Install llvmpipe and lavapipe for offscreen canvas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,6 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
-
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
 [tool.hatch.build.targets.wheel]
@@ -61,11 +57,11 @@ pyqt = [
     "pyqt6 >=6.4,!=6.6",
     "pyqt6 >=6.5.3; python_version >= '3.12'",
     "qtpy >=2",
-    "superqt[iconify] @ git+https://github.com/tlambert03/superqt@less-rename",
+    "superqt[iconify] >=0.7.1",
 ]
 pyside = [
     # defer to superqt's pyside6 restrictions
-    "superqt[iconify,pyside6] @ git+https://github.com/tlambert03/superqt@less-rename",
+    "superqt[iconify,pyside6] >=0.7.1",
     # https://github.com/pyapp-kit/ndv/issues/59
     "pyside6 ==6.6.3; sys_platform == 'win32'",
     "numpy >=1.23,<2; sys_platform == 'win32'",  # needed for pyside6.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
+
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
 [tool.hatch.build.targets.wheel]
@@ -57,11 +61,11 @@ pyqt = [
     "pyqt6 >=6.4,!=6.6",
     "pyqt6 >=6.5.3; python_version >= '3.12'",
     "qtpy >=2",
-    "superqt[iconify] >=0.7.1",
+    "superqt[iconify] @ git+https://github.com/tlambert03/superqt@less-rename",
 ]
 pyside = [
     # defer to superqt's pyside6 restrictions
-    "superqt[iconify,pyside6] >=0.7.1",
+    "superqt[iconify,pyside6] @ git+https://github.com/tlambert03/superqt@less-rename",
     # https://github.com/pyapp-kit/ndv/issues/59
     "pyside6 ==6.6.3; sys_platform == 'win32'",
     "numpy >=1.23,<2; sys_platform == 'win32'",  # needed for pyside6.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,11 @@ pyqt = [
     "pyqt6 >=6.4,!=6.6",
     "pyqt6 >=6.5.3; python_version >= '3.12'",
     "qtpy >=2",
-    "superqt[iconify] >=0.7.1",
+    "superqt[iconify] >=0.7.2",
 ]
 pyside = [
     # defer to superqt's pyside6 restrictions
-    "superqt[iconify,pyside6] >=0.7.1",
+    "superqt[iconify,pyside6] >=0.7.2",
     # https://github.com/pyapp-kit/ndv/issues/59
     "pyside6 ==6.6.3; sys_platform == 'win32'",
     "numpy >=1.23,<2; sys_platform == 'win32'",  # needed for pyside6.6

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -3288,15 +3287,14 @@ requires-dist = [
     { name = "qtpy", marker = "extra == 'pyqt'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'pyside'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'qt'", specifier = ">=2" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
-    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", specifier = ">=0.7.1" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", specifier = ">=0.7.1" },
+    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", specifier = ">=0.7.1" },
     { name = "typing-extensions", specifier = ">=4.0" },
     { name = "vispy", marker = "extra == 'vispy'", specifier = ">=0.14.3" },
     { name = "wxpython", marker = "extra == 'wx'", specifier = ">=4.2.2" },
     { name = "wxpython", marker = "extra == 'wxpython'", specifier = ">=4.2.2" },
 ]
-provides-extras = ["jup", "jupyter", "pygfx", "pyqt", "pyside", "qt", "vispy", "wx", "wxpython"]
 
 [package.metadata.requires-dev]
 array-libs = [
@@ -5531,12 +5529,16 @@ wheels = [
 
 [[package]]
 name = "superqt"
-version = "0.7.1.dev17+g5acc3bf"
-source = { git = "https://github.com/tlambert03/superqt?rev=less-rename#5acc3bf170ff1d717850014941a79979859a604d" }
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "qtpy" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/28/3b3afeb6e1efd9095d18a43a60d851dede470e95297ff694d3d75e704926/superqt-0.7.1.tar.gz", hash = "sha256:dade2953916e9adff912e08a337e322b5f4603c780ed92505515489598d73960", size = 101188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/43/4f2393a5203b53e94dfd9f7e408bc4caeed5ead51868b091578c6a5aaaf5/superqt-0.7.1-py3-none-any.whl", hash = "sha256:c40df8d63bc06e0b7a3ec01c2c41c901fee03e2177c17eafabd6cfd157aa99ed", size = 95107 },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -3287,14 +3288,15 @@ requires-dist = [
     { name = "qtpy", marker = "extra == 'pyqt'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'pyside'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'qt'", specifier = ">=2" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", specifier = ">=0.7.1" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", specifier = ">=0.7.1" },
-    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", specifier = ">=0.7.1" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
+    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", git = "https://github.com/tlambert03/superqt?rev=less-rename" },
     { name = "typing-extensions", specifier = ">=4.0" },
     { name = "vispy", marker = "extra == 'vispy'", specifier = ">=0.14.3" },
     { name = "wxpython", marker = "extra == 'wx'", specifier = ">=4.2.2" },
     { name = "wxpython", marker = "extra == 'wxpython'", specifier = ">=4.2.2" },
 ]
+provides-extras = ["jup", "jupyter", "pygfx", "pyqt", "pyside", "qt", "vispy", "wx", "wxpython"]
 
 [package.metadata.requires-dev]
 array-libs = [
@@ -5529,16 +5531,12 @@ wheels = [
 
 [[package]]
 name = "superqt"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.7.1.dev17+g5acc3bf"
+source = { git = "https://github.com/tlambert03/superqt?rev=less-rename#5acc3bf170ff1d717850014941a79979859a604d" }
 dependencies = [
     { name = "pygments" },
     { name = "qtpy" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/28/3b3afeb6e1efd9095d18a43a60d851dede470e95297ff694d3d75e704926/superqt-0.7.1.tar.gz", hash = "sha256:dade2953916e9adff912e08a337e322b5f4603c780ed92505515489598d73960", size = 101188 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/43/4f2393a5203b53e94dfd9f7e408bc4caeed5ead51868b091578c6a5aaaf5/superqt-0.7.1-py3-none-any.whl", hash = "sha256:c40df8d63bc06e0b7a3ec01c2c41c901fee03e2177c17eafabd6cfd157aa99ed", size = 95107 },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3287,9 +3287,9 @@ requires-dist = [
     { name = "qtpy", marker = "extra == 'pyqt'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'pyside'", specifier = ">=2" },
     { name = "qtpy", marker = "extra == 'qt'", specifier = ">=2" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", specifier = ">=0.7.1" },
-    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", specifier = ">=0.7.1" },
-    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", specifier = ">=0.7.1" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'pyqt'", specifier = ">=0.7.2" },
+    { name = "superqt", extras = ["iconify"], marker = "extra == 'qt'", specifier = ">=0.7.2" },
+    { name = "superqt", extras = ["iconify", "pyside6"], marker = "extra == 'pyside'", specifier = ">=0.7.2" },
     { name = "typing-extensions", specifier = ">=4.0" },
     { name = "vispy", marker = "extra == 'vispy'", specifier = ">=0.14.3" },
     { name = "wxpython", marker = "extra == 'wx'", specifier = ">=4.2.2" },
@@ -5529,16 +5529,16 @@ wheels = [
 
 [[package]]
 name = "superqt"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "qtpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/28/3b3afeb6e1efd9095d18a43a60d851dede470e95297ff694d3d75e704926/superqt-0.7.1.tar.gz", hash = "sha256:dade2953916e9adff912e08a337e322b5f4603c780ed92505515489598d73960", size = 101188 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ba/2a99869363916a77eb97e0e8d2f4718e9c486e9799a2a86efffe4c7f44fb/superqt-0.7.2.tar.gz", hash = "sha256:b1407d1a36afbdc7cdbddc6e95cec2b7d9514145da12da29dddb81b45feb7827", size = 101375 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/43/4f2393a5203b53e94dfd9f7e408bc4caeed5ead51868b091578c6a5aaaf5/superqt-0.7.1-py3-none-any.whl", hash = "sha256:c40df8d63bc06e0b7a3ec01c2c41c901fee03e2177c17eafabd6cfd157aa99ed", size = 95107 },
+    { url = "https://files.pythonhosted.org/packages/55/ba/5aba8696d7168bfc565a5dcbc407aae1ec508059ef3a88836442f91fe194/superqt-0.7.2-py3-none-any.whl", hash = "sha256:c93c6a9f41ab81e61d61c7495541b15db7ce2b2fb1a0504658c1611317eddf19", size = 95175 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
With https://github.com/pyapp-kit/superqt/pull/283 in, I think our segfaults will be mostly fixed, so this PR ~removes the retries and simplifies ci.yml~

eh... looks like there are a couple residual sporadic segfaults.   so I'm going to leave in the retries.  this just repins superqt, and updates the setup-headless-display action