### PR TITLE
fix: add tensorstore dtype property to tensorstore  DataWrapper

### DIFF
--- a/src/ndv/models/_data_wrapper.py
+++ b/src/ndv/models/_data_wrapper.py
@@ -430,7 +430,7 @@ class TensorstoreWrapper(DataWrapper["ts.TensorStore"]):
     def dtype(self) -> np.dtype:
         """Return the dtype for the data."""
         try:
-            return np.dtype(str(self._data.dtype.name))  # type: ignore
+            return np.dtype(str(self._data.dtype.name))
         except AttributeError as e:
             raise NotImplementedError(
                 "`dtype` property not properly implemented for DataWrapper of type: "

--- a/src/ndv/models/_data_wrapper.py
+++ b/src/ndv/models/_data_wrapper.py
@@ -429,13 +429,7 @@ class TensorstoreWrapper(DataWrapper["ts.TensorStore"]):
     @property
     def dtype(self) -> np.dtype:
         """Return the dtype for the data."""
-        try:
-            return np.dtype(str(self._data.dtype.name))
-        except AttributeError as e:
-            raise NotImplementedError(
-                "`dtype` property not properly implemented for DataWrapper of type: "
-                f"{type(self)}"
-            ) from e
+        return np.dtype(str(self._data.dtype.name))
 
     @property
     def dims(self) -> tuple[Hashable, ...]:

--- a/src/ndv/models/_data_wrapper.py
+++ b/src/ndv/models/_data_wrapper.py
@@ -427,6 +427,17 @@ class TensorstoreWrapper(DataWrapper["ts.TensorStore"]):
         }
 
     @property
+    def dtype(self) -> np.dtype:
+        """Return the dtype for the data."""
+        try:
+            return np.dtype(str(self._data.dtype.name))  # type: ignore
+        except AttributeError as e:
+            raise NotImplementedError(
+                "`dtype` property not properly implemented for DataWrapper of type: "
+                f"{type(self)}"
+            ) from e
+
+    @property
     def dims(self) -> tuple[Hashable, ...]:
         """Return the dimension labels for the data."""
         return self._dims


### PR DESCRIPTION
I was using `ndv` with `pymmcore-gui` and noticed this error while opening the histogram:

```
While emitting signal 'ndv.views._qt._array_view.QtArrayView.histogramRequested', an error occurred in a callback:

  TypeError: Cannot interpret 'dtype("uint16")' as a data type
  ------------------------------------------------------------

  SIGNAL EMISSION:
    /Users/fdrgsp/Documents/git/pymmcore-gui/src/pymmcore_gui/_app.py:103 in main
      app.exec()
    /Users/fdrgsp/Documents/git/pymmcore-gui/.venv/lib/python3.12/site-packages/ndv/views/_qt/_array_view.py:253 in _on_q_histogram_toggled
      self.histogramRequested.emit(self._channel)  # <-- SIGNAL WAS EMITTED HERE

  CALLBACK CHAIN:
    src/psygnal/_signal.py:1279 in _run_emit_loop
    ... 4 more frames ...
    /Users/fdrgsp/Documents/git/pymmcore-gui/.venv/lib/python3.12/site-packages/ndv/models/_data_wrapper.py:147 in dtype
      return np.dtype(self._data.dtype)  # type: ignore  # <-- ERROR OCCURRED HERE
```

In the `TensorstoreWrapper`, `self._data.dtype` is of type `tensorstore.dtype`, which requires the use of `.name` to extract the actual `dtype` in a format compatible with `np.dtype` ( [tensorstore.dtype](https://google.github.io/tensorstore/python/api/tensorstore.dtype.html)).

This PR adds the `dtype` property to the `TensorstoreWrapper`.