### PR TITLE
fix: block ContextMenu events on vispy

### DIFF
--- a/src/ndv/views/_qt/_app.py
+++ b/src/ndv/views/_qt/_app.py
@@ -132,7 +132,7 @@ class MouseEventFilter(QObject):
             qevent.type() == qevent.Type.ContextMenu
             and type(obj).__name__ == "CanvasBackendDesktop"
         ):
-            return False
+            return False  # pragma: no cover
         if obj is self.canvas or obj in children:
             if isinstance(qevent, QMouseEvent):
                 pos = qevent.pos()


### PR DESCRIPTION
fixes #160 

looks like that bug (which is a strange one).  is cause by two things:

- the `MouseEventFilter` calls the `QMouseEvent.pos()` prior to letting vispy also handle the event ... seems harmless enough (doesn't store it in any way)
- the vispy  receiver of the event *stores* a pointer of the event in a dictionary [here](https://github.com/vispy/vispy/blob/524ffa7d78ff173a0db9b07c04ab8c37d2068b81/vispy/app/base.py#L186).  (this reference is the key problem).

looks like if we just "disallow" ContextMenu events on the vispy canvas for now this is avoided.  I think this is a safe long-term fix (the implication is just that we never pass `ContextMenu` events to vispy)