### PR TITLE
docs: clarify no pyqt6 on conda

### DIFF
--- a/docs/js/install-table.js
+++ b/docs/js/install-table.js
@@ -19,7 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
     "PyPI,Pygfx,PySide6": `${pipCommand} "ndv[pygfx,pyside]"`,
     "PyPI,Pygfx,wxPython": `${pipCommand} "ndv[pygfx,wxpython]"`,
     "PyPI,Pygfx,Jupyter": `${pipCommand} "ndv[pygfx,jupyter]"`,
-    "Conda,VisPy,PyQt6": `${condaCommand} ndv ${condaVispy} qt6-main`,
+    "Conda,VisPy,PyQt6": `pyqt6 is not available in conda-forge, use PySide6`,
     "Conda,VisPy,PySide6": `${condaCommand} ndv ${condaVispy} 'pyside6<6.8'`,
     "Conda,VisPy,wxPython": `${condaCommand} ndv ${condaVispy} wxpython`,
     "Conda,VisPy,Jupyter": `${condaCommand} ndv ${condaVispy} ${condaJupyter}`,


### PR DESCRIPTION
I think our pyqt6 install method on conda is wrong... i think conda-forge still doesn't have pyqt6 (please anyone correct me if I'm wrong).  This updates the install page to clarify that it's just not available and to use pyside6 on conda