### PR TITLE
feat: Purge ArrayDataDisplayModel from ArrayViews

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -435,7 +435,7 @@ class ArrayViewer:
         self._data_model.display.current_index.update(self._view.current_index())
 
     def _on_view_ndims_requested(self, ndims: int) -> None:
-        """Update the model when the visible axes change."""
+        """Update the model when the user requests ndims visualized axes."""
         # TODO: Disable 3D mode when only 2 axes?
         current_axes = self.display_model.visible_axes
         if len(current_axes) > 2:

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -101,9 +101,7 @@ class ArrayViewer:
 
         # TODO: Is this necessary?
         self._histograms: dict[ChannelKey, HistogramCanvas] = {}
-        self._view = frontend_cls(
-            self._canvas.frontend_widget(), self._data_model, self._viewer_model
-        )
+        self._view = frontend_cls(self._canvas.frontend_widget(), self._viewer_model)
 
         self._roi_view: RectangularROIHandle | None = None
 

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -114,7 +114,7 @@ class ArrayViewer:
         self._view.resetZoomClicked.connect(self._on_view_reset_zoom_clicked)
         self._view.histogramRequested.connect(self._add_histogram)
         self._view.channelModeChanged.connect(self._on_view_channel_mode_changed)
-        self._view.visibleAxesChanged.connect(self._on_view_visible_axes_changed)
+        self._view.nDimsRequested.connect(self._on_view_ndims_requested)
 
         self._canvas.mouseMoved.connect(self._on_canvas_mouse_moved)
 
@@ -152,7 +152,7 @@ class ArrayViewer:
         self._fully_synchronize_view()
 
     @property
-    def data_wrapper(self) -> Any:
+    def data_wrapper(self) -> DataWrapper | None:
         """Return data being displayed."""
         return self._data_model.data_wrapper
 
@@ -436,9 +436,26 @@ class ArrayViewer:
         """Update the model when slider value changes."""
         self._data_model.display.current_index.update(self._view.current_index())
 
-    def _on_view_visible_axes_changed(self) -> None:
+    def _on_view_ndims_requested(self, ndims: int) -> None:
         """Update the model when the visible axes change."""
-        self.display_model.visible_axes = self._view.visible_axes()  # type: ignore [assignment]
+        # TODO: Disable 3D mode when only 2 axes?
+        current_axes = self.display_model.visible_axes
+        if len(current_axes) > 2:
+            if ndims == 2:  # is now 2D
+                self.display_model.visible_axes = current_axes[-2:]
+        else:
+            z_ax = None
+            # Check the data wrapper for a guess on the z axis
+            if wrapper := self._data_model.data_wrapper:
+                z_ax = wrapper.guess_z_axis()
+            # In absence of a (valid) guess, just choose the last dimension that is
+            # not in the visible axes.
+            if z_ax is None or z_ax in current_axes:
+                sld = reversed(self.data_wrapper.dims)  # type: ignore
+                z_ax = next(
+                    ax for ax in sld if ax not in self._data_model.normed_visible_axes
+                )
+            self.display_model.visible_axes = (z_ax, *current_axes)
 
     def _on_view_reset_zoom_clicked(self) -> None:
         """Reset the zoom level of the canvas."""

--- a/src/ndv/views/_jupyter/_array_view.py
+++ b/src/ndv/views/_jupyter/_array_view.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from vispy.app.backends import _jupyter_rfb
 
     from ndv._types import AxisKey, ChannelKey
-    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
 
 # not entirely sure why it's necessary to specifically annotat signals as : PSignal
@@ -266,13 +265,11 @@ class JupyterArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: _jupyter_rfb.CanvasBackend,
-        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
     ) -> None:
         self._viewer_model = viewer_model
         self._viewer_model.events.connect(self._on_viewer_model_event)
         # WIDGETS
-        self._data_model = data_model
         self._canvas_widget = canvas_widget
         self._visible_axes: Sequence[AxisKey] = []
         self._luts: dict[ChannelKey, JupyterLutView] = {}

--- a/src/ndv/views/_jupyter/_array_view.py
+++ b/src/ndv/views/_jupyter/_array_view.py
@@ -497,22 +497,7 @@ class JupyterArrayView(ArrayView):
         self._ndims_btn.value = len(axes) == 3
 
     def _on_ndims_toggled(self, change: dict[str, Any]) -> None:
-        if len(self._visible_axes) > 2:
-            if not change["new"]:  # is now 2D
-                self._visible_axes = self._visible_axes[-2:]
-        else:
-            z_ax = None
-            if wrapper := self._data_model.data_wrapper:
-                z_ax = wrapper.guess_z_axis()
-            if z_ax is None:
-                # get the last slider that is not in visible axes
-                z_ax = next(
-                    ax for ax in reversed(self._sliders) if ax not in self._visible_axes
-                )
-            self._visible_axes = (z_ax, *self._visible_axes)
-        # TODO: a future PR may decide to set this on the model directly...
-        # since we now have access to it.
-        self.visibleAxesChanged.emit()
+        self.nDimsRequested.emit(3 if change["new"] else 2)
 
     def _on_reset_zoom_clicked(self, change: dict[str, Any]) -> None:
         self.resetZoomClicked.emit()

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
     from qtpy.QtGui import QIcon
 
     from ndv._types import AxisKey, ChannelKey
-    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
     from ndv.views.bases._graphics._canvas_elements import (
         CanvasElement,
@@ -775,10 +774,8 @@ class QtArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: QWidget,
-        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
     ) -> None:
-        self._data_model = data_model
         self._viewer_model = viewer_model
         self._qwidget = qwdg = _QArrayViewer(canvas_widget)
         # Mapping of channel key to LutViews

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -838,22 +838,8 @@ class QtArrayView(ArrayView):
         self._qwidget.dims_sliders.set_current_index(value)
 
     def _on_ndims_toggled(self, is_3d: bool) -> None:
-        if len(self._visible_axes) > 2:
-            if not is_3d:  # is now 2D
-                self._visible_axes = self._visible_axes[-2:]
-        else:
-            z_ax = None
-            if wrapper := self._data_model.data_wrapper:
-                z_ax = wrapper.guess_z_axis()
-            if z_ax is None:
-                # get the last slider that is not in visible axes
-                sld = reversed(self._qwidget.dims_sliders._sliders)
-                z_ax = next(ax for ax in sld if ax not in self._visible_axes)
-            self._visible_axes = (z_ax, *self._visible_axes)
-        # TODO: a future PR may decide to set this on the model directly...
-        # since we now have access to it.
         self._qwidget.dims_sliders.stop_animations()
-        self.visibleAxesChanged.emit()
+        self.nDimsRequested.emit(3 if is_3d else 2)
 
     def visible_axes(self) -> Sequence[AxisKey]:
         return self._visible_axes  # no widget to control this yet

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -506,21 +506,7 @@ class WxArrayView(ArrayView):
 
     def _on_ndims_toggled(self, event: wx.CommandEvent) -> None:
         is_3d = self._wxwidget.ndims_btn.GetValue()
-        if len(self._visible_axes) > 2:
-            if not is_3d:  # is now 2D
-                self._visible_axes = self._visible_axes[-2:]
-        else:
-            z_ax = None
-            if wrapper := self._data_model.data_wrapper:
-                z_ax = wrapper.guess_z_axis()
-            if z_ax is None:
-                # get the last slider that is not in visible axes
-                sld = reversed(self._wxwidget.dims_sliders._sliders)
-                z_ax = next(ax for ax in sld if ax not in self._visible_axes)
-            self._visible_axes = (z_ax, *self._visible_axes)
-        # TODO: a future PR may decide to set this on the model directly...
-        # since we now have access to it.
-        self.visibleAxesChanged.emit()
+        self.nDimsRequested.emit(3 if is_3d else 2)
 
     def _on_add_roi_toggled(self, event: wx.CommandEvent) -> None:
         create_roi = self._wxwidget.add_roi_btn.GetValue()

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     import cmap
 
     from ndv._types import AxisKey, ChannelKey
-    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
 
 
@@ -479,11 +478,9 @@ class WxArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: wx.Window,
-        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
         parent: wx.Window = None,
     ) -> None:
-        self._data_model = data_model
         self._viewer_model = viewer_model
         self._viewer_model.events.connect(self._on_viewer_model_event)
         self._wxwidget = wdg = _WxArrayViewer(canvas_widget, parent)

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from collections.abc import Container, Hashable, Mapping, Sequence
 
     from ndv._types import AxisKey, ChannelKey
-    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.models._viewer_model import ArrayViewerModel
     from ndv.views.bases import LutView
 
@@ -38,7 +37,6 @@ class ArrayView(Viewable):
     def __init__(
         self,
         canvas_widget: Any,
-        model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
         **kwargs: Any,
     ) -> None: ...

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -30,7 +30,7 @@ class ArrayView(Viewable):
     currentIndexChanged = Signal()
     resetZoomClicked = Signal()
     histogramRequested = Signal(int)
-    visibleAxesChanged = Signal()
+    nDimsRequested = Signal(int)
     channelModeChanged = Signal(ChannelMode)
 
     # model: _ArrayDataDisplayModel is likely a temporary parameter

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import pytest
 
+from ndv import process_events
 from ndv._types import (
     CursorType,
     MouseButton,
@@ -237,13 +238,9 @@ def test_array_viewer_with_app() -> None:
     visax_mock = Mock()
     viewer.display_model.events.visible_axes.connect(visax_mock)
     viewer._view.nDimsRequested.emit(3)
-
-    # FIXME:
-    # calling set_visible_axes on wx during testing is not triggering the
-    # _on_ndims_toggled callback... and I don't know enough about wx yet to know why.
-    if gui_frontend() != _app.GuiFrontend.WX:
-        visax_mock.assert_called_once()
-        assert viewer.display_model.visible_axes == (2, -2, -1)
+    process_events()
+    visax_mock.assert_called_once()
+    assert viewer.display_model.visible_axes == (2, -2, -1)
 
 
 @pytest.mark.usefixtures("any_app")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -118,9 +118,8 @@ def test_controller() -> None:
     assert model.current_index == idx
 
     # when the view sets 3 dimensions, the model is updated
-    mock_view.visible_axes.return_value = (0, -2, -1)
-    ctrl._on_view_visible_axes_changed()
-    assert model.visible_axes == (0, -2, -1)
+    ctrl._on_view_ndims_requested(3)
+    assert model.visible_axes == (2, 0, 3)
 
     # when the view changes the channel mode, the model is updated
     assert model.channel_mode == ChannelMode.GRAYSCALE
@@ -213,14 +212,14 @@ def test_array_viewer_with_app() -> None:
     assert viewer.display_model.visible_axes == (-2, -1)
     visax_mock = Mock()
     viewer.display_model.events.visible_axes.connect(visax_mock)
-    viewer._view.set_visible_axes((0, -2, -1))
+    viewer._view.nDimsRequested.emit(3)
 
     # FIXME:
     # calling set_visible_axes on wx during testing is not triggering the
     # _on_ndims_toggled callback... and I don't know enough about wx yet to know why.
     if gui_frontend() != _app.GuiFrontend.WX:
         visax_mock.assert_called_once()
-        assert viewer.display_model.visible_axes == (0, -2, -1)
+        assert viewer.display_model.visible_axes == (2, -2, -1)
 
 
 @pytest.mark.usefixtures("any_app")

--- a/tests/views/_jupyter/test_array_view.py
+++ b/tests/views/_jupyter/test_array_view.py
@@ -5,16 +5,13 @@ from unittest.mock import Mock
 import ipywidgets
 from pytest import fixture
 
-from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._jupyter._array_view import JupyterArrayView
 
 
 @fixture
 def viewer() -> JupyterArrayView:
-    viewer = JupyterArrayView(
-        ipywidgets.DOMWidget(), _ArrayDataDisplayModel(), ArrayViewerModel()
-    )
+    viewer = JupyterArrayView(ipywidgets.DOMWidget(), ArrayViewerModel())
     viewer.add_lut_view(None)
     return viewer
 

--- a/tests/views/_qt/test_array_view.py
+++ b/tests/views/_qt/test_array_view.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 from pytest import fixture
 from qtpy.QtWidgets import QWidget
 
-from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._app import get_histogram_canvas_class
 from ndv.views._qt._array_view import PlayButton, QtArrayView
@@ -17,7 +16,7 @@ if TYPE_CHECKING:
 
 @fixture
 def viewer(qtbot: QtBot) -> QtArrayView:
-    viewer = QtArrayView(QWidget(), _ArrayDataDisplayModel(), ArrayViewerModel())
+    viewer = QtArrayView(QWidget(), ArrayViewerModel())
     viewer.add_lut_view(None)
     viewer.create_sliders({0: range(10), 1: range(64), 2: range(128)})
     qtbot.addWidget(viewer.frontend_widget())

--- a/tests/views/_wx/test_array_view.py
+++ b/tests/views/_wx/test_array_view.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock
 import wx
 from pytest import fixture
 
-from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._app import get_histogram_canvas_class
 from ndv.views._wx._array_view import WxArrayView
@@ -13,7 +12,7 @@ from ndv.views._wx._array_view import WxArrayView
 
 @fixture
 def viewer(wxapp: wx.App) -> WxArrayView:
-    viewer = WxArrayView(MagicMock(), _ArrayDataDisplayModel(), ArrayViewerModel())
+    viewer = WxArrayView(MagicMock(), ArrayViewerModel())
     viewer.add_lut_view(None)
     return viewer
 


### PR DESCRIPTION
The goal of this PR is to minimize the footprint of the `ArrayDataDisplayModel` by removing its usage within the `ArrayView`s. It is a potential alternative/complement to #184.

It turns out that the only reason the `ArrayDataDisplayModel` is being passed to the views is so that the array views could decide on the best dimension to visualize in the case we were moving from 2 dimensions to 3. I think this design is suboptimal as:
* It allows business logic in the views, when that logic should really be in the controller.
* That logic must be present in each `ArrayView` (i.e. it's WET)

The reason I hesitate with this change though is because I'd love a world where all views in NDV know about and operate directly on their associated models; this change goes against that by removing models (granted, models I dislike 😅) from the views, instead propagating desires indirectly to the model via signals. However, I think there's a difference between the model-view interactions involved in #87:
* With LUTs right now, the interactions are just "model parameter X should be Y"
* Here, the interaction is "model parameter `visible_axes` should be 3 items long" - information is still missing, which needs to be filled in. In that respect, it's like all of the other operations where we use signals.

So I'm not sure whether it's a final solution, but I do hope it's a step towards one by restricting the usage of `ArrayDataDisplayModel` for later refactoring.