### PR TITLE
fix: fix composite mode on init

### DIFF
--- a/examples/numpy_arr.py
+++ b/examples/numpy_arr.py
@@ -14,4 +14,4 @@ except Exception as e:
     print(e)
     img = ndv.data.nd_sine_wave((10, 3, 8, 512, 512))
 
-viewer = ndv.imshow(img)
+viewer = ndv.imshow(img, current_index={0: 30}, channel_mode="composite")

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -73,8 +73,10 @@ class ArrayViewer:
                 stacklevel=2,
             )
 
-        self._data_model = _ArrayDataDisplayModel(display=display_model)
-        self._set_data_wrapper(wrapper)
+        self._data_model = _ArrayDataDisplayModel(
+            display=display_model, data_wrapper=wrapper
+        )
+        self._connect_datawrapper(None, wrapper)
 
         self._viewer_model = ArrayViewerModel.model_validate(viewer_options or {})
         self._viewer_model.events.interaction_mode.connect(
@@ -169,20 +171,22 @@ class ArrayViewer:
     @data.setter
     def data(self, data: Any) -> None:
         """Set the data to be displayed."""
-        self._set_data_wrapper(data)
-        self._fully_synchronize_view()
-
-    def _set_data_wrapper(self, data: Any | None) -> None:
-        """Set new datawrapper and hook up events."""
         _new = None if data is None else DataWrapper.create(data)
         self._data_model.data_wrapper, old = _new, self._data_model.data_wrapper
+        self._connect_datawrapper(old, _new)
+        self._fully_synchronize_view()
+
+    def _connect_datawrapper(
+        self, old: DataWrapper | None, new: DataWrapper | None
+    ) -> None:
+        """Set new datawrapper and hook up events."""
         if old is not None:
             with suppress(Exception):
                 old.data_changed.disconnect(self._request_data)
                 old.dims_changed.disconnect(self._fully_synchronize_view)
-        if _new is not None:
-            _new.data_changed.connect(self._request_data)
-            _new.dims_changed.connect(self._fully_synchronize_view)
+        if new is not None:
+            new.data_changed.connect(self._request_data)
+            new.dims_changed.connect(self._fully_synchronize_view)
 
     @property
     def roi(self) -> RectangularROIModel | None:

--- a/src/ndv/models/_data_display_model.py
+++ b/src/ndv/models/_data_display_model.py
@@ -17,7 +17,7 @@ from pydantic import Field
 from ndv._types import ChannelKey
 from ndv.views import _app
 
-from ._array_display_model import ArrayDisplayModel, ChannelMode, TwoOrThreeAxisTuple
+from ._array_display_model import ArrayDisplayModel, ChannelMode
 from ._base_model import NDVModel
 from ._data_wrapper import DataWrapper
 
@@ -84,7 +84,16 @@ class _ArrayDataDisplayModel(NDVModel):
         # connect the channel mode change signal to the channel axis guessing method
         self.display.events.channel_mode.connect(self._on_channel_mode_change)
         # initial model synchronization
+        self._inject_channel_axis()
         self._on_channel_mode_change()
+
+    def _inject_channel_axis(self) -> None:
+        if (
+            self.display.channel_axis is None
+            and (wrapper := self.data_wrapper) is not None
+            and (guess := wrapper.guess_channel_axis()) not in self.normed_visible_axes
+        ):
+            self.display.channel_axis = guess
 
     def _on_channel_mode_change(self) -> None:
         # TODO: Refactor into separate methods?
@@ -92,27 +101,21 @@ class _ArrayDataDisplayModel(NDVModel):
         if mode == ChannelMode.GRAYSCALE:
             self.display.channel_axis = None
         elif mode in {ChannelMode.COLOR, ChannelMode.COMPOSITE}:
-            if self.data_wrapper is not None:
-                guess = self.data_wrapper.guess_channel_axis()
-                # only use the guess if it's not already in the visible axes
-                self.display.channel_axis = (
-                    None if guess in self.normed_visible_axes else guess
-                )
+            self._inject_channel_axis()
         elif mode == ChannelMode.RGBA:
             if self.data_wrapper is not None and self.display.channel_axis is None:
                 # Coerce image to RGB
                 if len(self.normed_visible_axes) == 3:
                     raise Exception("")
-                guess = self.data_wrapper.guess_channel_axis()
-                self.display.channel_axis = guess
-                # FIXME? going back another ChannelMode retains these changes
-                if guess in self.normed_visible_axes:
-                    dims = list(self.data_wrapper.sizes().keys())
-                    dims.remove(guess)
-                    new_visible_axes = dims[-self.display.n_visible_axes :]
-                    self.display.visible_axes = cast(
-                        "TwoOrThreeAxisTuple", tuple(new_visible_axes)
-                    )
+                self._inject_channel_axis()
+                # # FIXME? going back another ChannelMode retains these changes
+                # if guess in self.normed_visible_axes:
+                #     dims = list(self.data_wrapper.sizes().keys())
+                #     dims.remove(guess)
+                #     new_visible_axes = dims[-self.display.n_visible_axes :]
+                #     self.display.visible_axes = cast(
+                #         "TwoOrThreeAxisTuple", tuple(new_visible_axes)
+                #     )
 
     # Properties for normalized data access -----------------------------------------
     # these all use positive integers as axis keys


### PR DESCRIPTION
fixes #197 

The core problem was that the whole "guess channel axis" hadn't triggered by the time the canvas was drawn.  the example works fine if you pass in an explicit channel axis, so we just need to do a better job of coordinating the timing of that magic.

This gets the example working... but I need to check whether some other things have been broken