### PR TITLE
fix: update hover on new data

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -117,7 +117,7 @@ class ArrayViewer:
         self._view.channelModeChanged.connect(self._on_view_channel_mode_changed)
         self._view.nDimsRequested.connect(self._on_view_ndims_requested)
 
-        self._last_mouse_pos: tuple[int, int] | None = None
+        self._highlight_pos: tuple[int, int] | None = None
         self._canvas.mouseMoved.connect(self._on_canvas_mouse_moved)
         self._canvas.mouseLeft.connect(self._on_canvas_mouse_left)
 
@@ -473,16 +473,16 @@ class ArrayViewer:
     def _on_canvas_mouse_moved(self, event: MouseMoveEvent) -> None:
         """Respond to a mouse move event in the view."""
         x, y, _z = self._canvas.canvas_to_world((event.x, event.y))
-        self._last_mouse_pos = (int(x), int(y))
+        self._highlight_pos = (int(x), int(y))
 
-        # collect and format intensity values at the current mouse position
-        channel_values = self._get_values_at_world_point(*self._last_mouse_pos)
-        self._highlight_values(channel_values, self._last_mouse_pos)
+        # update highlight display
+        channel_values = self._get_values_at_world_point(*self._highlight_pos)
+        self._highlight_values(channel_values, self._highlight_pos)
 
     def _on_canvas_mouse_left(self) -> None:
         """Respond to a mouse leaving the canvas in the view."""
-        self._last_mouse_pos = None
-        self._highlight_values({}, self._last_mouse_pos)
+        self._highlight_pos = None
+        self._highlight_values({}, self._highlight_pos)
 
     def _on_view_channel_mode_changed(self, mode: ChannelMode) -> None:
         self._data_model.display.channel_mode = mode
@@ -643,10 +643,10 @@ class ArrayViewer:
                 hist.set_data(counts, bin_edges)
 
         self._canvas.refresh()
-        # collect and format intensity values at the current mouse position
-        if self._last_mouse_pos is not None:
-            channel_values = self._get_values_at_world_point(*self._last_mouse_pos)
-            self._highlight_values(channel_values, self._last_mouse_pos)
+        # update highlight display
+        if self._highlight_pos is not None:
+            channel_values = self._get_values_at_world_point(*self._highlight_pos)
+            self._highlight_values(channel_values, self._highlight_pos)
 
     def _get_values_at_world_point(self, x: int, y: int) -> dict[ChannelKey, float]:
         # TODO: handle 3D data

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -117,6 +117,7 @@ class ArrayViewer:
         self._view.channelModeChanged.connect(self._on_view_channel_mode_changed)
         self._view.nDimsRequested.connect(self._on_view_ndims_requested)
 
+        self._last_mouse_pos: tuple[int, int] | None = None
         self._canvas.mouseMoved.connect(self._on_canvas_mouse_moved)
         self._canvas.mouseLeft.connect(self._on_canvas_mouse_left)
 
@@ -472,15 +473,16 @@ class ArrayViewer:
     def _on_canvas_mouse_moved(self, event: MouseMoveEvent) -> None:
         """Respond to a mouse move event in the view."""
         x, y, _z = self._canvas.canvas_to_world((event.x, event.y))
+        self._last_mouse_pos = (int(x), int(y))
 
         # collect and format intensity values at the current mouse position
-        channel_values = self._get_values_at_world_point(int(x), int(y))
-
-        self._highlight_values(channel_values, (x, y))
+        channel_values = self._get_values_at_world_point(*self._last_mouse_pos)
+        self._highlight_values(channel_values, self._last_mouse_pos)
 
     def _on_canvas_mouse_left(self) -> None:
         """Respond to a mouse leaving the canvas in the view."""
-        self._highlight_values({})
+        self._last_mouse_pos = None
+        self._highlight_values({}, self._last_mouse_pos)
 
     def _on_view_channel_mode_changed(self, mode: ChannelMode) -> None:
         self._data_model.display.channel_mode = mode
@@ -641,6 +643,10 @@ class ArrayViewer:
                 hist.set_data(counts, bin_edges)
 
         self._canvas.refresh()
+        # collect and format intensity values at the current mouse position
+        if self._last_mouse_pos is not None:
+            channel_values = self._get_values_at_world_point(*self._last_mouse_pos)
+            self._highlight_values(channel_values, self._last_mouse_pos)
 
     def _get_values_at_world_point(self, x: int, y: int) -> dict[ChannelKey, float]:
         # TODO: handle 3D data

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -165,6 +165,20 @@ def test_canvas_interaction() -> None:
     mock_view.reset_mock()
     mock_histogram.reset_mock()
 
+    # updating the image also updates the hover info in the view
+    # NB Since the image handle is a mock, the data won't be updated.
+    ctrl.data = np.empty(SHAPE, dtype=np.uint8)
+    # FIXME: These methods are actually called twice, both within
+    # _fully_synchronize_view. The first time is on
+    # ArrayViewer._on_view_current_index_change, and the second on
+    # ArrayViewer._request_data
+    mock_view.set_hover_info.assert_called_with("[2, 1] 0")
+    mock_histogram.highlight.assert_called_with(0)
+
+    mock_canvas.reset_mock()
+    mock_view.reset_mock()
+    mock_histogram.reset_mock()
+
     # hovering off the image clears the hover info in the view
     mock_canvas.canvas_to_world.return_value = (-1, -1, 3)
     ctrl._on_canvas_mouse_moved(MouseMoveEvent(-1, -1))


### PR DESCRIPTION
Closes #199.

We need to update the hover info whenever:
1. The user moves the mouse
2. The displayed data is updated under the mouse

Only the first case was previously covered.

To cover (2), we must keep track of the mouse position. Currently, this state is stored within the `ArrayViewer` and updated whenever (1) occurs. This state *could* potentially live in the `ArrayViewerModel` instead, if we find it helpful for other tasks.