### PR TITLE
Make image showing functions thread-safer

### DIFF
--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -104,7 +104,9 @@ class ArrayViewer:
 
         if self._data_model.data_wrapper is not None:
             # Queue view synchronization to main thread as well since it involves GUI operations
-            sync_future = _app.ndv_app().call_in_main_thread(self._fully_synchronize_view)
+            sync_future = _app.ndv_app().call_in_main_thread(
+                self._fully_synchronize_view
+            )
             sync_future.result()
 
     def _init_gui_components(self) -> None:

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -103,7 +103,8 @@ class ArrayViewer:
         init_future.result()
 
         if self._data_model.data_wrapper is not None:
-            # Queue view synchronization to main thread as well since it involves GUI operations
+            # Queue view synchronization to main thread as well
+            # since it involves GUI operations
             sync_future = _app.ndv_app().call_in_main_thread(
                 self._fully_synchronize_view
             )

--- a/src/ndv/controllers/_array_viewer.py
+++ b/src/ndv/controllers/_array_viewer.py
@@ -97,6 +97,18 @@ class ArrayViewer:
         # where None is the default channel
         self._lut_controllers: dict[ChannelKey, ChannelController] = {}
 
+        # Thread-safe initialization: queue GUI-sensitive operations to main thread
+        init_future = _app.ndv_app().call_in_main_thread(self._init_gui_components)
+        # Block until GUI components are initialized
+        init_future.result()
+
+        if self._data_model.data_wrapper is not None:
+            # Queue view synchronization to main thread as well since it involves GUI operations
+            sync_future = _app.ndv_app().call_in_main_thread(self._fully_synchronize_view)
+            sync_future.result()
+
+    def _init_gui_components(self) -> None:
+        """Initialize GUI components that must be created on the main thread."""
         # get and create the front-end and canvas classes
         frontend_cls = _app.get_array_view_class()
         canvas_cls = _app.get_array_canvas_class()
@@ -120,9 +132,6 @@ class ArrayViewer:
         self._highlight_pos: tuple[int, int] | None = None
         self._canvas.mouseMoved.connect(self._on_canvas_mouse_moved)
         self._canvas.mouseLeft.connect(self._on_canvas_mouse_left)
-
-        if self._data_model.data_wrapper is not None:
-            self._fully_synchronize_view()
 
     # -------------- public attributes and methods -------------------------
 
@@ -208,15 +217,22 @@ class ArrayViewer:
 
     def show(self) -> None:
         """Show the viewer."""
-        self._view.set_visible(True)
+        # Queue GUI operation to main thread to ensure thread safety
+        show_future = _app.ndv_app().call_in_main_thread(self._view.set_visible, True)
+        # Block until operation completes to maintain synchronous behavior
+        show_future.result()
 
     def hide(self) -> None:
         """Hide the viewer."""
-        self._view.set_visible(False)
+        # Queue GUI operation to main thread to ensure thread safety
+        hide_future = _app.ndv_app().call_in_main_thread(self._view.set_visible, False)
+        hide_future.result()
 
     def close(self) -> None:
         """Close the viewer."""
-        self._view.set_visible(False)
+        # Queue GUI operation to main thread to ensure thread safety
+        close_future = _app.ndv_app().call_in_main_thread(self._view.set_visible, False)
+        close_future.result()
 
     def clone(self) -> ArrayViewer:
         """Return a new ArrayViewer instance with the same data and display model.


### PR DESCRIPTION
This patch improves ndv's image showing functions to work more seamlessly when called from non-main threads, especially on macOS.

Below is an MCVE script that illustrates the problem before this patch. Without this patch, commenting out the `@ensure_main_thread` decorator causes the program to crash, whereas with this patch, the program works with or without the decorator in place.

Note that the patch itself was written by Claude.ai, not me, so I won't be offended by any harsh criticism. 😆 

```python
import sys
import threading
import time

from qtpy.QtWidgets import QApplication


def create_and_show_random_image() -> "ndv.ArrayViewer":
    from ndv import ArrayViewer
    import numpy
    from ndv.views._app import ensure_main_thread

    @ensure_main_thread  # Comment out this decorator to observe the crash.
    def show(data, **kwargs):
        viewer = ArrayViewer(data)
        viewer.show()
        return viewer

    data = numpy.random.random([300, 200])
    retval = show(data)
    return retval.result() if hasattr(retval, 'result') else retval


def do_stuff_later():
    print("I'll do it in a sec...")
    time.sleep(1)
    print("Time to show some images!")
    for _ in range(3):
        print("Showing an image...")
        viewer = create_and_show_random_image()
        viewers.append(viewer)
        print(f"Viewers -> {viewers}")
    print("All images shown.")


# Create QApplication on main thread.
print("Creating Qt application...")
app = QApplication(sys.argv)

viewers = []

threading.Thread(target=do_stuff_later).start()

print("Starting Qt loop...")
app.exec()

print("That's it! Go home to your pets!")
```
