### PR TITLE
Revert "feat: Purge ArrayDataDisplayModel from ArrayViews (#196)"

### DIFF
--- a/src/ndv/views/_jupyter/_array_view.py
+++ b/src/ndv/views/_jupyter/_array_view.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from vispy.app.backends import _jupyter_rfb
 
     from ndv._types import AxisKey, ChannelKey
+    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
 
 # not entirely sure why it's necessary to specifically annotat signals as : PSignal
@@ -383,11 +384,13 @@ class JupyterArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: _jupyter_rfb.CanvasBackend,
+        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
     ) -> None:
         self._viewer_model = viewer_model
         self._viewer_model.events.connect(self._on_viewer_model_event)
         # WIDGETS
+        self._data_model = data_model
         self._canvas_widget = canvas_widget
         self._visible_axes: Sequence[AxisKey] = []
         self._luts: dict[ChannelKey, JupyterLutView] = {}
@@ -616,7 +619,22 @@ class JupyterArrayView(ArrayView):
         self._ndims_btn.value = len(axes) == 3
 
     def _on_ndims_toggled(self, change: dict[str, Any]) -> None:
-        self.nDimsRequested.emit(3 if change["new"] else 2)
+        if len(self._visible_axes) > 2:
+            if not change["new"]:  # is now 2D
+                self._visible_axes = self._visible_axes[-2:]
+        else:
+            z_ax = None
+            if wrapper := self._data_model.data_wrapper:
+                z_ax = wrapper.guess_z_axis()
+            if z_ax is None:
+                # get the last slider that is not in visible axes
+                z_ax = next(
+                    ax for ax in reversed(self._sliders) if ax not in self._visible_axes
+                )
+            self._visible_axes = (z_ax, *self._visible_axes)
+        # TODO: a future PR may decide to set this on the model directly...
+        # since we now have access to it.
+        self.visibleAxesChanged.emit()
 
     def _on_reset_zoom_clicked(self, change: dict[str, Any]) -> None:
         self.resetZoomClicked.emit()

--- a/src/ndv/views/_qt/_array_view.py
+++ b/src/ndv/views/_qt/_array_view.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from qtpy.QtGui import QIcon
 
     from ndv._types import AxisKey, ChannelKey
+    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
     from ndv.views.bases._graphics._canvas_elements import (
         CanvasElement,
@@ -782,8 +783,10 @@ class QtArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: QWidget,
+        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
     ) -> None:
+        self._data_model = data_model
         self._viewer_model = viewer_model
         self._qwidget = qwdg = _QArrayViewer(canvas_widget)
         # Mapping of channel key to LutViews
@@ -847,8 +850,22 @@ class QtArrayView(ArrayView):
         self._qwidget.dims_sliders.set_current_index(value)
 
     def _on_ndims_toggled(self, is_3d: bool) -> None:
+        if len(self._visible_axes) > 2:
+            if not is_3d:  # is now 2D
+                self._visible_axes = self._visible_axes[-2:]
+        else:
+            z_ax = None
+            if wrapper := self._data_model.data_wrapper:
+                z_ax = wrapper.guess_z_axis()
+            if z_ax is None:
+                # get the last slider that is not in visible axes
+                sld = reversed(self._qwidget.dims_sliders._sliders)
+                z_ax = next(ax for ax in sld if ax not in self._visible_axes)
+            self._visible_axes = (z_ax, *self._visible_axes)
+        # TODO: a future PR may decide to set this on the model directly...
+        # since we now have access to it.
         self._qwidget.dims_sliders.stop_animations()
-        self.nDimsRequested.emit(3 if is_3d else 2)
+        self.visibleAxesChanged.emit()
 
     def visible_axes(self) -> Sequence[AxisKey]:
         return self._visible_axes  # no widget to control this yet

--- a/src/ndv/views/_wx/_array_view.py
+++ b/src/ndv/views/_wx/_array_view.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Container, Hashable, Mapping, Sequence
 
     from ndv._types import AxisKey, ChannelKey
+    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.views.bases._graphics._canvas import HistogramCanvas
 
 
@@ -702,9 +703,11 @@ class WxArrayView(ArrayView):
     def __init__(
         self,
         canvas_widget: wx.Window,
+        data_model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
         parent: wx.Window = None,
     ) -> None:
+        self._data_model = data_model
         self._viewer_model = viewer_model
         self._viewer_model.events.connect(self._on_viewer_model_event)
         self._wxwidget = wdg = _WxArrayViewer(canvas_widget, parent)
@@ -727,7 +730,21 @@ class WxArrayView(ArrayView):
 
     def _on_ndims_toggled(self, event: wx.CommandEvent) -> None:
         is_3d = self._wxwidget.ndims_btn.GetValue()
-        self.nDimsRequested.emit(3 if is_3d else 2)
+        if len(self._visible_axes) > 2:
+            if not is_3d:  # is now 2D
+                self._visible_axes = self._visible_axes[-2:]
+        else:
+            z_ax = None
+            if wrapper := self._data_model.data_wrapper:
+                z_ax = wrapper.guess_z_axis()
+            if z_ax is None:
+                # get the last slider that is not in visible axes
+                sld = reversed(self._wxwidget.dims_sliders._sliders)
+                z_ax = next(ax for ax in sld if ax not in self._visible_axes)
+            self._visible_axes = (z_ax, *self._visible_axes)
+        # TODO: a future PR may decide to set this on the model directly...
+        # since we now have access to it.
+        self.visibleAxesChanged.emit()
 
     def _on_add_roi_toggled(self, event: wx.CommandEvent) -> None:
         create_roi = self._wxwidget.add_roi_btn.GetValue()

--- a/src/ndv/views/bases/_array_view.py
+++ b/src/ndv/views/bases/_array_view.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Container, Hashable, Mapping, Sequence
 
     from ndv._types import AxisKey, ChannelKey
+    from ndv.models._data_display_model import _ArrayDataDisplayModel
     from ndv.models._viewer_model import ArrayViewerModel
     from ndv.views.bases import LutView
 
@@ -29,7 +30,7 @@ class ArrayView(Viewable):
     currentIndexChanged = Signal()
     resetZoomClicked = Signal()
     histogramRequested = Signal(int)
-    nDimsRequested = Signal(int)
+    visibleAxesChanged = Signal()
     channelModeChanged = Signal(ChannelMode)
 
     # model: _ArrayDataDisplayModel is likely a temporary parameter
@@ -37,6 +38,7 @@ class ArrayView(Viewable):
     def __init__(
         self,
         canvas_widget: Any,
+        model: _ArrayDataDisplayModel,
         viewer_model: ArrayViewerModel,
         **kwargs: Any,
     ) -> None: ...

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import pytest
 
-from ndv import process_events
 from ndv._types import (
     CursorType,
     MouseButton,
@@ -119,8 +118,9 @@ def test_controller() -> None:
     assert model.current_index == idx
 
     # when the view sets 3 dimensions, the model is updated
-    ctrl._on_view_ndims_requested(3)
-    assert model.visible_axes == (2, 0, 3)
+    mock_view.visible_axes.return_value = (0, -2, -1)
+    ctrl._on_view_visible_axes_changed()
+    assert model.visible_axes == (0, -2, -1)
 
     # when the view changes the channel mode, the model is updated
     assert model.channel_mode == ChannelMode.GRAYSCALE
@@ -251,10 +251,14 @@ def test_array_viewer_with_app() -> None:
     assert viewer.display_model.visible_axes == (-2, -1)
     visax_mock = Mock()
     viewer.display_model.events.visible_axes.connect(visax_mock)
-    viewer._view.nDimsRequested.emit(3)
-    process_events()
-    visax_mock.assert_called_once()
-    assert viewer.display_model.visible_axes == (2, -2, -1)
+    viewer._view.set_visible_axes((0, -2, -1))
+
+    # FIXME:
+    # calling set_visible_axes on wx during testing is not triggering the
+    # _on_ndims_toggled callback... and I don't know enough about wx yet to know why.
+    if gui_frontend() != _app.GuiFrontend.WX:
+        visax_mock.assert_called_once()
+        assert viewer.display_model.visible_axes == (0, -2, -1)
 
 
 @pytest.mark.usefixtures("any_app")

--- a/tests/views/_jupyter/test_array_view.py
+++ b/tests/views/_jupyter/test_array_view.py
@@ -5,13 +5,16 @@ from unittest.mock import Mock
 import ipywidgets
 from pytest import fixture
 
+from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._jupyter._array_view import JupyterArrayView
 
 
 @fixture
 def viewer() -> JupyterArrayView:
-    viewer = JupyterArrayView(ipywidgets.DOMWidget(), ArrayViewerModel())
+    viewer = JupyterArrayView(
+        ipywidgets.DOMWidget(), _ArrayDataDisplayModel(), ArrayViewerModel()
+    )
     viewer.add_lut_view(None)
     return viewer
 

--- a/tests/views/_qt/test_array_view.py
+++ b/tests/views/_qt/test_array_view.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from pytest import fixture
 from qtpy.QtWidgets import QWidget
 
+from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._app import get_histogram_canvas_class
 from ndv.views._qt._array_view import PlayButton, QtArrayView
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 @fixture
 def viewer(qtbot: QtBot) -> QtArrayView:
-    viewer = QtArrayView(QWidget(), ArrayViewerModel())
+    viewer = QtArrayView(QWidget(), _ArrayDataDisplayModel(), ArrayViewerModel())
     viewer.add_lut_view(None)
     viewer.create_sliders({0: range(10), 1: range(64), 2: range(128)})
     qtbot.addWidget(viewer.frontend_widget())

--- a/tests/views/_wx/test_array_view.py
+++ b/tests/views/_wx/test_array_view.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock
 import wx
 from pytest import fixture
 
+from ndv.models._data_display_model import _ArrayDataDisplayModel
 from ndv.models._viewer_model import ArrayViewerModel
 from ndv.views._app import get_histogram_canvas_class
 from ndv.views._wx._array_view import WxArrayView
@@ -12,7 +13,7 @@ from ndv.views._wx._array_view import WxArrayView
 
 @fixture
 def viewer(wxapp: wx.App) -> WxArrayView:
-    viewer = WxArrayView(MagicMock(), ArrayViewerModel())
+    viewer = WxArrayView(MagicMock(), _ArrayDataDisplayModel(), ArrayViewerModel())
     viewer.add_lut_view(None)
     return viewer
 


### PR DESCRIPTION
This reverts commit 17e1d0c8556971202dc939c0af2fbca68e092716.

we *do* like the changes introduced by that PR, but it is breaking tests on macos and linux (see #205).  The os-difference is probably due to race conditions that are revealed on some OS but not all (but they are issues nonetheless).  It may come down to needing to improve the request/response framework, but until that's fixed, the nice code structure introduced in #196 is still less important than a functioning viewer.